### PR TITLE
fix: #2269 incorrect super admin count issues

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/service/impl/AppSetupServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/service/impl/AppSetupServiceImpl.java
@@ -5,9 +5,12 @@ import com.skapp.community.common.payload.response.ResponseEntityDto;
 import com.skapp.community.common.repository.OrganizationConfigDao;
 import com.skapp.community.common.service.AppSetupStatusService;
 import com.skapp.community.peopleplanner.repository.EmployeeRoleDao;
+import com.skapp.community.peopleplanner.type.AccountStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +27,8 @@ public class AppSetupServiceImpl implements AppSetupStatusService {
 
 		OrganizationStatusResponseDto organizationStatusResponseDto = new OrganizationStatusResponseDto();
 		organizationStatusResponseDto.setIsOrganizationSetupCompleted(organizationConfigDao.count() > 0);
-		organizationStatusResponseDto.setIsSignUpCompleted(employeeRoleDao.existsByIsSuperAdminTrue());
+		organizationStatusResponseDto.setIsSignUpCompleted(employeeRoleDao
+			.existsByIsSuperAdminTrueAndEmployee_AccountStatusIn(Set.of(AccountStatus.ACTIVE, AccountStatus.PENDING)));
 
 		log.info("getAppSetupStatus: execution ended");
 		return new ResponseEntityDto(false, organizationStatusResponseDto);

--- a/backend/src/main/java/com/skapp/community/common/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/service/impl/AuthServiceImpl.java
@@ -180,7 +180,8 @@ public class AuthServiceImpl implements AuthService {
 	public ResponseEntityDto superAdminSignUp(SuperAdminSignUpRequestDto superAdminSignUpRequestDto) {
 		log.info("superAdminSignUp: execution started");
 
-		boolean isSuperAdminExists = isSuperAdminExists();
+		boolean isSuperAdminExists = employeeRoleDao
+			.existsByIsSuperAdminTrueAndEmployee_AccountStatusIn(Set.of(AccountStatus.ACTIVE, AccountStatus.PENDING));
 		if (isSuperAdminExists) {
 			throw new ModuleException(CommonMessageConstant.COMMON_ERROR_SUPER_ADMIN_ALREADY_EXISTS);
 		}
@@ -489,10 +490,6 @@ public class AuthServiceImpl implements AuthService {
 
 		log.info("createNotificationSettings: execution ended");
 		return userSettings;
-	}
-
-	private boolean isSuperAdminExists() {
-		return employeeRoleDao.existsByIsSuperAdminTrue();
 	}
 
 	protected void createNewPassword(String newPassword, User user) {

--- a/backend/src/main/java/com/skapp/community/peopleplanner/repository/EmployeeRoleDao.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/repository/EmployeeRoleDao.java
@@ -2,20 +2,22 @@ package com.skapp.community.peopleplanner.repository;
 
 import com.skapp.community.common.type.Role;
 import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.community.peopleplanner.type.AccountStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
-public interface EmployeeRoleDao extends JpaRepository<EmployeeRole, Long> {
+public interface EmployeeRoleDao extends JpaRepository<EmployeeRole, Long>, EmployeeRepository {
 
-	boolean existsByIsSuperAdminTrue();
-
-	long countByIsSuperAdminTrue();
+	boolean existsByIsSuperAdminTrueAndEmployee_AccountStatusIn(Set<AccountStatus> accountStatuses);
 
 	List<EmployeeRole> findEmployeesByPeopleRole(Role roleName);
 
 	long countByEsignRoleAndIsSuperAdmin(Role roleName, boolean isSuperAdmin);
+
+	long countByIsSuperAdminTrueAndEmployee_AccountStatusIn(Set<AccountStatus> accountStatuses);
 
 }

--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/RolesServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/RolesServiceImpl.java
@@ -29,6 +29,7 @@ import com.skapp.community.peopleplanner.repository.EmployeeRoleDao;
 import com.skapp.community.peopleplanner.repository.ModuleRoleRestrictionDao;
 import com.skapp.community.peopleplanner.repository.TeamDao;
 import com.skapp.community.peopleplanner.service.RolesService;
+import com.skapp.community.peopleplanner.type.AccountStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @Slf4j
@@ -222,7 +224,8 @@ public class RolesServiceImpl implements RolesService {
 	public ResponseEntityDto getSuperAdminCount() {
 		log.info("getSuperAdminCount: execution started");
 
-		long superAdminCount = employeeRoleDao.countByIsSuperAdminTrue();
+		long superAdminCount = employeeRoleDao
+			.countByIsSuperAdminTrueAndEmployee_AccountStatusIn(Set.of(AccountStatus.ACTIVE, AccountStatus.PENDING));
 
 		log.info("getSuperAdminCount: execution ended");
 		return new ResponseEntityDto(false, superAdminCount);
@@ -266,7 +269,9 @@ public class RolesServiceImpl implements RolesService {
 
 		if (userRoles != null && user.getEmployee() != null
 				&& Boolean.TRUE.equals(user.getEmployee().getEmployeeRole().getIsSuperAdmin())
-				&& employeeRoleDao.countByIsSuperAdminTrue() == 1 && isUserRoleDowngraded(userRoles)) {
+				&& employeeRoleDao.countByIsSuperAdminTrueAndEmployee_AccountStatusIn(
+						Set.of(AccountStatus.ACTIVE, AccountStatus.PENDING)) == 1
+				&& isUserRoleDowngraded(userRoles)) {
 			throw new ModuleException(PeopleMessageConstant.PEOPLE_ERROR_ONLY_ONE_SUPER_ADMIN);
 		}
 


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of super admin status by incorporating account status checks (`ACTIVE` and `PENDING`) across multiple services and repositories. The changes ensure that only active or pending accounts are considered when verifying or counting super admins. Additionally, redundant methods have been removed for improved code maintainability.

### Enhancements to super admin status handling:

* Updated the `existsByIsSuperAdminTrue` and `countByIsSuperAdminTrue` methods in `EmployeeRoleDao` to include account status checks, ensuring only `ACTIVE` and `PENDING` accounts are considered.
* Modified the `getAppSetupStatus` method in `AppSetupServiceImpl` to use the updated `existsByIsSuperAdminTrueAndEmployee_AccountStatusIn` method for checking super admin existence.
* Updated the `superAdminSignUp` method in `AuthServiceImpl` to verify super admin existence using the new account status-aware method.
* Enhanced the `getSuperAdminCount` and `validateRoles` methods in `RolesServiceImpl` to use the updated `countByIsSuperAdminTrueAndEmployee_AccountStatusIn` method for accurate super admin count validation. [[1]](diffhunk://#diff-494b25640c156ca0446cfa0f617fcd32b4b19521e587f30bfbac303d501f560dL225-R228) [[2]](diffhunk://#diff-494b25640c156ca0446cfa0f617fcd32b4b19521e587f30bfbac303d501f560dL269-R274)

### Code cleanup:

* Removed the redundant `isSuperAdminExists` method from `AuthServiceImpl`, as its functionality is now covered by the updated repository methods.

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/2269) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
