### PR TITLE
fix: changed the onClose to set the open state to false

### DIFF
--- a/frontend/src/community/common/components/organisms/ContentWithDrawer/ContentWithDrawer.tsx
+++ b/frontend/src/community/common/components/organisms/ContentWithDrawer/ContentWithDrawer.tsx
@@ -66,7 +66,9 @@ const ContentWithDrawer = ({ children }: Props) => {
         autoHideDuration={toastMessage.autoHideDuration}
         handleToastClick={toastMessage.handleToastClick}
         isIcon={toastMessage.isIcon}
-        onClose={() => setToastMessage(initialState)}
+        onClose={() => {
+            setToastMessage((state) => ({ ...state, open: false }));
+          }}
       />
       <TimeWidgetPopupController />
       <MyRequestModalController />

--- a/frontend/src/community/common/components/organisms/ContentWithoutDrawer/ContentWithoutDrawer.tsx
+++ b/frontend/src/community/common/components/organisms/ContentWithoutDrawer/ContentWithoutDrawer.tsx
@@ -31,7 +31,9 @@ const ContentWithoutDrawer = ({ children }: Props) => {
           autoHideDuration={toastMessage.autoHideDuration}
           handleToastClick={toastMessage.handleToastClick}
           isIcon={toastMessage.isIcon}
-          onClose={() => setToastMessage(initialState)}
+          onClose={() => {
+            setToastMessage((state) => ({ ...state, open: false }));
+          }}
         />
       </Stack>
     </>


### PR DESCRIPTION
## PR checklist

### TaskId: After displaying a toast message, an unintended toast appears when the original toast disappears.
[#2521](https://github.com/rootcodelabs/skapp-ep/issues/2521) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
