### PR TITLE
Fix/2606 leave   apply leave – leave summary shows wrong leave duration when a leave already exists for the selected day

### DIFF
--- a/frontend/src/community/leave/components/molecules/MyLeaveRequestsModals/ApplyLeaveModal/ApplyLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/MyLeaveRequestsModals/ApplyLeaveModal/ApplyLeaveModal.tsx
@@ -450,6 +450,7 @@ const ApplyLeaveModal = () => {
               setAttachments(attachments.filter((a) => a !== attachment))
             }
           />
+          {!isApplyLeaveModalBtnDisabled ?
           <LeaveSummary
             leaveTypeName={selectedLeaveAllocationData.leaveType.name}
             leaveTypeEmoji={selectedLeaveAllocationData.leaveType.emojiCode}
@@ -458,7 +459,8 @@ const ApplyLeaveModal = () => {
             endDate={selectedDates[1]}
             resourceAvailability={resourceAvailability}
             workingDays={workingDays}
-          />
+          /> : <></> }
+          
         </Stack>
       </Stack>
       <Stack sx={classes.btnWrapper}>

--- a/frontend/src/community/leave/components/molecules/MyLeaveRequestsModals/ApplyLeaveModal/ApplyLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/MyLeaveRequestsModals/ApplyLeaveModal/ApplyLeaveModal.tsx
@@ -450,17 +450,17 @@ const ApplyLeaveModal = () => {
               setAttachments(attachments.filter((a) => a !== attachment))
             }
           />
-          {!isApplyLeaveModalBtnDisabled ?
-          <LeaveSummary
-            leaveTypeName={selectedLeaveAllocationData.leaveType.name}
-            leaveTypeEmoji={selectedLeaveAllocationData.leaveType.emojiCode}
-            leaveDuration={selectedDuration}
-            startDate={selectedDates[0]}
-            endDate={selectedDates[1]}
-            resourceAvailability={resourceAvailability}
-            workingDays={workingDays}
-          /> : <></> }
-          
+          {!isApplyLeaveModalBtnDisabled && (
+            <LeaveSummary
+              leaveTypeName={selectedLeaveAllocationData.leaveType.name}
+              leaveTypeEmoji={selectedLeaveAllocationData.leaveType.emojiCode}
+              leaveDuration={selectedDuration}
+              startDate={selectedDates[0]}
+              endDate={selectedDates[1]}
+              resourceAvailability={resourceAvailability}
+              workingDays={workingDays}
+            />
+          )}
         </Stack>
       </Stack>
       <Stack sx={classes.btnWrapper}>


### PR DESCRIPTION
…ame day is again selected

## PR checklist

### TaskId:Leave - Apply Leave – Leave summary shows wrong leave duraion when a leave already exists for the selected day
[#2606](https://github.com/rootcodelabs/skapp-ep/issues/2606) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
