### PR TITLE
fix: block guest users from core project list page (#2179)

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -152,7 +152,10 @@ const employeeRoutes = {
     ...commonRoutes
   ],
   [EmployeeTypes.PM_EMPLOYEE]: [...commonRoutes],
-  [EmployeeTypes.PM_GUEST_EMPLOYEE]: [...commonRoutes],
+  // Guests must not reach the core-side project list page, so exclude it
+  [EmployeeTypes.PM_GUEST_EMPLOYEE]: commonRoutes.filter(
+    (route) => route !== ROUTES.PROJECTS.BASE
+  ),
   [RepresentativeTypes.CRM_SALES_REPRESENTATIVE]: [
     ROUTES.CRM.BASE,
     ...commonRoutes


### PR DESCRIPTION
## Description

Guest users (`PM_GUEST_EMPLOYEE`) were being granted access to the **core-side project list page** (`/projects/list`).

### Root cause
In `frontend/middleware.ts`, the guest role was assigned the full `commonRoutes` set, which includes `ROUTES.PROJECTS.BASE` (`/projects/list`). The middleware `isAllowed` check matches routes via `pathname.startsWith(url)`, so guests could reach the core project list page directly by URL — even after the Skapp-logo click was disabled on the PM side.

### Fix
Exclude `ROUTES.PROJECTS.BASE` from the guest role's allowed routes so guests are redirected to `/unauthorized` instead.

```ts
[EmployeeTypes.PM_GUEST_EMPLOYEE]: commonRoutes.filter(
  (route) => route !== ROUTES.PROJECTS.BASE
),
```

### Why this is safe
- The guest verify flow (`pages/enterprise/verify/guest-otp.tsx`) redirects to `PROJECTS = "/pm/projects"` (the PM app), **not** `/projects/list`, so guest login/landing is unaffected.
- The middleware `matcher` covers `/projects/:path*` but **not** `/pm/*`, so the PM app is untouched.

## Related
Companion to the PM-app fix for issue #2179 (guest logo-click navigation + profile avatar visibility).

## Testing
- [x] `tsc --noEmit` passes (no middleware errors)
- [ ] Guest navigating to `/projects/list` is redirected to `/unauthorized`
- [ ] Guest verify → lands on `/pm/projects/{key}` as before
- [ ] Non-guest PM roles still access `/projects/list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)