### PR TITLE
[Fix] Restrict employee leave policies section to super admin or people+leave admin

### DIFF
--- a/frontend/src/community/leave/components/molecules/IndividualEmployeeLeaveReportSection/IndividualEmployeeLeaveReportSection.tsx
+++ b/frontend/src/community/leave/components/molecules/IndividualEmployeeLeaveReportSection/IndividualEmployeeLeaveReportSection.tsx
@@ -2,6 +2,7 @@ import { Stack } from "@mui/material";
 import { FC, useEffect, useMemo, useState } from "react";
 
 import PeopleLayout from "~community/common/components/templates/PeopleLayout/PeopleLayout";
+import useSessionData from "~community/common/hooks/useSessionData";
 import { useTranslator } from "~community/common/hooks/useTranslator";
 import { useGetLeaveTypes } from "~community/leave/api/LeaveApi";
 import UserAssignedLeaveTypes from "~community/leave/components/molecules/UserAssignedLeaveTypes/UserAssignedLeaveTypes";
@@ -10,7 +11,6 @@ import UserLeavePolicies from "~community/leave/components/molecules/UserLeavePo
 import UserLeavePoliciesSkeleton from "~community/leave/components/molecules/UserLeavePolicies/UserLeavePoliciesSkeleton";
 import UserLeaveUtilization from "~community/leave/components/molecules/UserLeaveUtilization/UserLeaveUtilization";
 import { USER_ASSIGNED_LEAVE_TYPES_PAGE_SIZE } from "~community/leave/constants/leavePolicyConstants";
-import useCanViewLeavePolicies from "~community/leave/hooks/useCanViewLeavePolicies";
 import useLeavePoliciesEnabled from "~community/leave/hooks/useLeavePoliciesEnabled";
 import { useLeaveStore } from "~community/leave/store/store";
 import { LeaveType } from "~community/leave/types/CustomLeaveAllocationTypes";
@@ -40,7 +40,11 @@ const IndividualEmployeeLeaveReportSection: FC<Props> = ({
 
   const { isAtLeastCoreTier } = useTier();
 
-  const canViewLeavePolicies = useCanViewLeavePolicies();
+  const { isSuperAdmin, isPeopleAdmin, isLeaveAdmin } = useSessionData();
+
+  const canViewLeavePolicies = Boolean(
+    isSuperAdmin || (isPeopleAdmin && isLeaveAdmin)
+  );
 
   const { isLeavePoliciesEnabled, isLoading: isLeavePolicyConfigLoading } =
     useLeavePoliciesEnabled();


### PR DESCRIPTION
## Summary

The **Leave policies** section on an employee's Leave tab (People → employee → Leave) was rendered for any leave admin, people admin or super admin. That section is a people-module surface and its data comes from the employee leave-policy assignment endpoint, so a user who only holds one of the two admin roles should not see it at all. Visibility is now restricted to a super admin, or a user holding **both** People Admin and Leave Admin.
