### PR TITLE
Fix/3010: Leave Policy - Duplicate policy name error shows as a toast instead of an inline field error

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/controller/v1/LeavePolicyController.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/controller/v1/LeavePolicyController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -34,6 +35,17 @@ public class LeavePolicyController {
 	@PreAuthorize("hasAnyRole('ROLE_LEAVE_ADMIN', 'ROLE_PEOPLE_ADMIN')")
 	public ResponseEntity<ResponseEntityDto> getAllLeavePolicies(LeavePolicyFilterDto leavePolicyFilterDto) {
 		ResponseEntityDto response = leavePolicyService.getAllLeavePolicies(leavePolicyFilterDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@Operation(summary = "Check leave policy name availability",
+			description = "Returns whether the given policy name is still available for the given leave type. "
+					+ "Names are compared case-insensitively across both active and inactive policies")
+	@GetMapping("/name-availability")
+	@PreAuthorize("hasAnyRole('ROLE_LEAVE_ADMIN')")
+	public ResponseEntity<ResponseEntityDto> checkLeavePolicyNameAvailability(
+			@RequestParam(required = false) String name, @RequestParam(required = false) Long leaveTypeId) {
+		ResponseEntityDto response = leavePolicyService.checkLeavePolicyNameAvailability(name, leaveTypeId);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 

--- a/backend/src/main/java/com/skapp/community/leaveplanner/payload/response/LeavePolicyNameAvailabilityResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/payload/response/LeavePolicyNameAvailabilityResponseDto.java
@@ -1,0 +1,16 @@
+package com.skapp.community.leaveplanner.payload.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeavePolicyNameAvailabilityResponseDto {
+
+	private Boolean isAvailable;
+
+}

--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/LeavePolicyService.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/LeavePolicyService.java
@@ -17,6 +17,8 @@ public interface LeavePolicyService {
 
 	ResponseEntityDto getAllLeavePolicies(LeavePolicyFilterDto leavePolicyFilterDto);
 
+	ResponseEntityDto checkLeavePolicyNameAvailability(String name, Long leaveTypeId);
+
 	ResponseEntityDto enableLeavePolicies();
 
 	ResponseEntityDto getLeavePolicyConfig();

--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeavePolicyServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeavePolicyServiceImpl.java
@@ -21,6 +21,7 @@ import com.skapp.community.leaveplanner.payload.request.LeavePolicyFilterDto;
 import com.skapp.community.leaveplanner.payload.request.LeavePolicyRequestDto;
 import com.skapp.community.leaveplanner.payload.request.LeavePolicyUpdateRequestDto;
 import com.skapp.community.leaveplanner.payload.response.LeavePolicyConfigResponseDto;
+import com.skapp.community.leaveplanner.payload.response.LeavePolicyNameAvailabilityResponseDto;
 import com.skapp.community.leaveplanner.payload.response.LeavePolicyResponseDto;
 import com.skapp.community.leaveplanner.payload.response.LeavePolicyStatusResponseDto;
 import com.skapp.community.leaveplanner.repository.LeaveEntitlementDao;
@@ -179,6 +180,23 @@ public class LeavePolicyServiceImpl implements LeavePolicyService {
 
 		log.info("getAllLeavePolicies: execution ended");
 		return new ResponseEntityDto(false, pageDto);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResponseEntityDto checkLeavePolicyNameAvailability(String name, Long leaveTypeId) {
+		log.info("checkLeavePolicyNameAvailability: execution started");
+
+		if (leaveTypeId == null) {
+			throw new ModuleException(LeaveMessageConstant.LEAVE_ERROR_LEAVE_POLICY_LEAVE_TYPE_REQUIRED);
+		}
+
+		LeavePolicyValidationUtil.validateName(name);
+
+		boolean isAvailable = !leavePolicyDao.existsByNameIgnoreCaseAndLeaveType_Id(name, leaveTypeId);
+
+		log.info("checkLeavePolicyNameAvailability: execution ended");
+		return new ResponseEntityDto(false, new LeavePolicyNameAvailabilityResponseDto(isAvailable));
 	}
 
 	@Override

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeavePolicyControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeavePolicyControllerIntegrationTest.java
@@ -46,6 +46,9 @@ class LeavePolicyControllerIntegrationTest {
 	private static final String SEED_LEAVE_TYPE = "INSERT INTO lv_leave_type (id, name, emoji_code, color_code, min_duration, is_attachment, is_attachment_must, is_comment_must, is_auto_approval, is_active) "
 			+ "VALUES (100, 'PolicyAnnual', 'U+1F3D6', '#FFC107', 'FULL_DAY', false, false, false, false, true)";
 
+	private static final String SEED_SECOND_LEAVE_TYPE = "INSERT INTO lv_leave_type (id, name, emoji_code, color_code, min_duration, is_attachment, is_attachment_must, is_comment_must, is_auto_approval, is_active) "
+			+ "VALUES (101, 'PolicyCasual', 'U+1F3D6', '#FFC107', 'FULL_DAY', false, false, false, false, true)";
+
 	private static final String SEED_POLICY = "INSERT INTO lv_leave_policy (id, name, leave_type_id, policy_type, status, is_carryover_enabled) "
 			+ "VALUES (500, 'Existing Policy', 100, 'ACCRUAL', 'ACTIVE', false)";
 
@@ -112,6 +115,13 @@ class LeavePolicyControllerIntegrationTest {
 	private ResultActions performGetAll(String authToken) throws Exception {
 		return mvc
 			.perform(get(ENDPOINT).accept(MediaType.APPLICATION_JSON).with(SecurityTestUtils.bearerToken(authToken)));
+	}
+
+	private ResultActions performNameAvailability(String authToken, String name, String leaveTypeId) throws Exception {
+		return mvc.perform(get(ENDPOINT + "/name-availability").param("name", name)
+			.param("leaveTypeId", leaveTypeId)
+			.accept(MediaType.APPLICATION_JSON)
+			.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performEnable(String authToken) throws Exception {
@@ -340,6 +350,93 @@ class LeavePolicyControllerIntegrationTest {
 				.with(SecurityTestUtils.bearerToken(leaveAdminToken())))
 				.andDo(print())
 				.andExpect(status().isNotFound());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Leave Policy Name Availability")
+	class LeavePolicyNameAvailabilityTests {
+
+		@Test
+		@DisplayName("Returns available when no policy holds the name for the leave type")
+		@Sql(statements = { SEED_LEAVE_TYPE, SEED_POLICY })
+		void checkNameAvailability_UnusedName_ReturnsAvailable() throws Exception {
+			performNameAvailability(leaveAdminToken(), "Brand New Policy", "100").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath("$.results[0].isAvailable").value(true));
+		}
+
+		@Test
+		@DisplayName("Returns unavailable when the name matches an existing policy ignoring case")
+		@Sql(statements = { SEED_LEAVE_TYPE, SEED_POLICY })
+		void checkNameAvailability_DuplicateNameDifferentCase_ReturnsUnavailable() throws Exception {
+			performNameAvailability(leaveAdminToken(), "existing policy", "100").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.results[0].isAvailable").value(false));
+		}
+
+		@Test
+		@DisplayName("Returns bad request when the name is missing")
+		@Sql(statements = { SEED_LEAVE_TYPE })
+		void checkNameAvailability_MissingName_ReturnsBadRequest() throws Exception {
+			mvc.perform(get(ENDPOINT + "/name-availability").param("leaveTypeId", "100")
+				.accept(MediaType.APPLICATION_JSON)
+				.with(SecurityTestUtils.bearerToken(leaveAdminToken())))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("Returns unavailable when the name is held by an inactive policy")
+		@Sql(statements = { SEED_LEAVE_TYPE, SEED_INACTIVE_POLICY })
+		void checkNameAvailability_InactivePolicyName_ReturnsUnavailable() throws Exception {
+			performNameAvailability(leaveAdminToken(), "Inactive Policy", "100").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.results[0].isAvailable").value(false));
+		}
+
+		@Test
+		@DisplayName("Returns available when the same name is used under a different leave type")
+		@Sql(statements = { SEED_LEAVE_TYPE, SEED_SECOND_LEAVE_TYPE, SEED_POLICY })
+		void checkNameAvailability_SameNameOtherLeaveType_ReturnsAvailable() throws Exception {
+			performNameAvailability(leaveAdminToken(), "Existing Policy", "101").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.results[0].isAvailable").value(true));
+		}
+
+		@Test
+		@DisplayName("Returns bad request when the name is blank")
+		@Sql(statements = { SEED_LEAVE_TYPE })
+		void checkNameAvailability_BlankName_ReturnsBadRequest() throws Exception {
+			performNameAvailability(leaveAdminToken(), "   ", "100").andDo(print()).andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("Returns bad request when the leave type is missing")
+		void checkNameAvailability_MissingLeaveTypeId_ReturnsBadRequest() throws Exception {
+			mvc.perform(get(ENDPOINT + "/name-availability").param("name", "Brand New Policy")
+				.accept(MediaType.APPLICATION_JSON)
+				.with(SecurityTestUtils.bearerToken(leaveAdminToken())))
+				.andDo(print())
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("Non-admin user cannot check policy name availability")
+		@Sql(statements = { SEED_LEAVE_TYPE, DOWNGRADE_USER2_TO_EMPLOYEE })
+		void checkNameAvailability_LeaveEmployee_ReturnsForbidden() throws Exception {
+			performNameAvailability(user2Token(), "Brand New Policy", "100").andDo(print())
+				.andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("Returns 401 when no authentication token is provided")
+		void checkNameAvailability_NoAuth_ReturnsUnauthorized() throws Exception {
+			mvc.perform(get(ENDPOINT + "/name-availability").param("name", "Brand New Policy")
+				.param("leaveTypeId", "100")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isUnauthorized());
 		}
 
 	}

--- a/frontend/src/community/common/assets/languages/english/leaveModule.json
+++ b/frontend/src/community/common/assets/languages/english/leaveModule.json
@@ -476,7 +476,8 @@
         "accrualCapStepInvalid": "Maximum balance must be in multiples of 0.5.",
         "maxCarryOverDaysRequired": "Please enter the maximum number of carry over days.",
         "maxCarryOverDaysInvalid": "Maximum carry over days must be greater than 0 and at most 365.",
-        "maxCarryOverDaysStepInvalid": "Maximum carry over days must be in multiples of 0.5."
+        "maxCarryOverDaysStepInvalid": "Maximum carry over days must be in multiples of 0.5.",
+        "policyNameDuplicate": "A policy with this name already exists for the selected leave type. Please use a different name."
       },
       "successToastTitle": "Policy Created",
       "successToastDescription": "Policy has been created successfully and is now active.",

--- a/frontend/src/community/leave/api/LeavePolicyApi.ts
+++ b/frontend/src/community/leave/api/LeavePolicyApi.ts
@@ -13,12 +13,15 @@ import { leavePolicyEndPoints } from "~community/leave/api/utils/ApiEndpoints";
 import { leavePolicyQueryKeys } from "~community/leave/api/utils/QueryKeys";
 import {
   AddLeavePolicyPayload,
+  CheckLeavePolicyNameAvailabilityParams,
   GetLeavePoliciesInfiniteArgs,
   GetLeavePoliciesParams,
   LeavePoliciesResponse,
   LeavePolicyConfigResponse,
   LeavePolicyConfigResult,
   LeavePolicyMutationResponse,
+  LeavePolicyNameAvailabilityResponse,
+  LeavePolicyNameAvailabilityResult,
   UpdateLeavePolicyVariables
 } from "~community/leave/types/LeavePolicyTypes";
 
@@ -64,6 +67,29 @@ export const useGetLeavePoliciesInfinite = ({
     refetchOnWindowFocus: false
   });
 };
+
+const checkLeavePolicyNameAvailability = async (
+  params: CheckLeavePolicyNameAvailabilityParams
+): Promise<LeavePolicyNameAvailabilityResult> => {
+  const response = await authFetch.get<LeavePolicyNameAvailabilityResponse>(
+    leavePolicyEndPoints.CHECK_LEAVE_POLICY_NAME_AVAILABILITY,
+    { params }
+  );
+  return response.data.results[0];
+};
+
+export const useCheckLeavePolicyNameAvailability = (): UseMutationResult<
+  LeavePolicyNameAvailabilityResult,
+  AxiosError,
+  CheckLeavePolicyNameAvailabilityParams
+> =>
+  useMutation<
+    LeavePolicyNameAvailabilityResult,
+    AxiosError,
+    CheckLeavePolicyNameAvailabilityParams
+  >({
+    mutationFn: checkLeavePolicyNameAvailability
+  });
 
 const addLeavePolicy = (
   leavePolicy: AddLeavePolicyPayload

--- a/frontend/src/community/leave/api/utils/ApiEndpoints.ts
+++ b/frontend/src/community/leave/api/utils/ApiEndpoints.ts
@@ -43,6 +43,7 @@ export const leavePolicyEndPoints = {
   ACTIVATE_LEAVE_POLICY: (id: number): string =>
     `${moduleAPIPath.LEAVE}/policies/${id}/activate`,
   GET_LEAVE_POLICIES: `${moduleAPIPath.LEAVE}/policies`,
+  CHECK_LEAVE_POLICY_NAME_AVAILABILITY: `${moduleAPIPath.LEAVE}/policies/name-availability`,
   ENABLE_LEAVE_POLICIES: `${moduleAPIPath.LEAVE}/policies/enable`,
   GET_LEAVE_POLICY_CONFIG: `${moduleAPIPath.LEAVE}/policies/config`
 };

--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -191,8 +191,6 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
 
       return isAvailable;
     } catch {
-      // The check is only a shortcut to an inline error. When it fails, let the
-      // create request run so the backend stays the authority on uniqueness.
       return true;
     }
   };

--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -182,9 +182,6 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
         currentValues?.leaveType !== checkedLeaveType;
 
       if (isStale) {
-        // The field was edited while the check was in flight, so this answer
-        // is about a name the user has moved on from. Stay put rather than
-        // flagging - or advancing - the wrong name.
         return false;
       }
 

--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -22,6 +22,7 @@ import {
 import { leavePolicyFormInitialValues } from "~community/leave/constants/leavePolicyConstants";
 import {
   LeavePolicyFormData,
+  LeavePolicyNameAvailabilityResult,
   LeavePolicyWizardSteps,
   PolicyType
 } from "~community/leave/types/LeavePolicyTypes";
@@ -129,7 +130,7 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
   );
 
   const {
-    mutateAsync: checkPolicyNameAvailability,
+    mutate: checkPolicyNameAvailability,
     isPending: isCheckingPolicyName
   } = useCheckLeavePolicyNameAvailability();
 
@@ -166,33 +167,26 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     }
   };
 
-  const isPolicyNameAvailable = async (): Promise<boolean> => {
-    const checkedName = formik.values.policyName.trim();
-    const checkedLeaveType = formik.values.leaveType;
-
-    try {
-      const { isAvailable } = await checkPolicyNameAvailability({
-        name: checkedName,
-        leaveTypeId: checkedLeaveType
-      });
-
-      const currentValues = formikRef.current?.values;
-      const isStale =
-        currentValues?.policyName.trim() !== checkedName ||
-        currentValues?.leaveType !== checkedLeaveType;
-
-      if (isStale) {
-        return false;
+  const proceedFromCurrentStep = async (): Promise<void> => {
+    if (isLastStep) {
+      if (!isPending) {
+        await formik.submitForm();
       }
-
-      if (!isAvailable) {
-        showDuplicatePolicyNameError();
-      }
-
-      return isAvailable;
-    } catch {
-      return true;
+      return;
     }
+
+    setActiveStep((previous) => previous + 1);
+  };
+
+  const handlePolicyNameAvailability = ({
+    isAvailable
+  }: LeavePolicyNameAvailabilityResult): void => {
+    if (!isAvailable) {
+      showDuplicatePolicyNameError();
+      return;
+    }
+
+    void proceedFromCurrentStep();
   };
 
   const advanceWizard = async (): Promise<void> => {
@@ -212,21 +206,21 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
       return;
     }
 
-    if (
-      activeStep === LeavePolicyWizardSteps.BASIC_INFO &&
-      !(await isPolicyNameAvailable())
-    ) {
+    if (activeStep === LeavePolicyWizardSteps.BASIC_INFO) {
+      checkPolicyNameAvailability(
+        {
+          name: formik.values.policyName.trim(),
+          leaveTypeId: formik.values.leaveType
+        },
+        {
+          onSuccess: handlePolicyNameAvailability,
+          onError: handleError
+        }
+      );
       return;
     }
 
-    if (isLastStep) {
-      if (!isPending) {
-        await formik.submitForm();
-      }
-      return;
-    }
-
-    setActiveStep((previous) => previous + 1);
+    await proceedFromCurrentStep();
   };
 
   const handleNext = async (): Promise<void> => {

--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -235,8 +235,6 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
   };
 
   const handleNext = async (): Promise<void> => {
-    // A second click while the availability check is still in flight would run
-    // the whole flow twice. isPending covers the create call itself.
     if (isAdvancingRef.current) {
       return;
     }

--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -15,7 +15,10 @@ import ROUTES from "~community/common/constants/routes";
 import { ToastType } from "~community/common/enums/ComponentEnums";
 import { useTranslator } from "~community/common/hooks/useTranslator";
 import { useToast } from "~community/common/providers/ToastProvider";
-import { useAddLeavePolicy } from "~community/leave/api/LeavePolicyApi";
+import {
+  useAddLeavePolicy,
+  useCheckLeavePolicyNameAvailability
+} from "~community/leave/api/LeavePolicyApi";
 import { leavePolicyFormInitialValues } from "~community/leave/constants/leavePolicyConstants";
 import {
   LeavePolicyFormData,
@@ -73,6 +76,7 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     useState<boolean>(false);
 
   const formikRef = useRef<FormikProps<LeavePolicyFormData> | null>(null);
+  const isAdvancingRef = useRef<boolean>(false);
 
   const steps = [
     translateText(["steps", "basicInfo"]),
@@ -94,14 +98,18 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     handleClose();
   };
 
+  const showDuplicatePolicyNameError = (): void => {
+    formikRef.current?.setFieldTouched("policyName", true, false);
+    formikRef.current?.setFieldError(
+      "policyName",
+      translateText(["errors", "policyNameDuplicate"])
+    );
+    setActiveStep(LeavePolicyWizardSteps.BASIC_INFO);
+  };
+
   const handleError = (error: AxiosError): void => {
     if (isDuplicatePolicyNameError(error)) {
-      formikRef.current?.setFieldTouched("policyName", true, false);
-      formikRef.current?.setFieldError(
-        "policyName",
-        translateText(["duplicateToastDescription"])
-      );
-      setActiveStep(LeavePolicyWizardSteps.BASIC_INFO);
+      showDuplicatePolicyNameError();
       return;
     }
 
@@ -119,6 +127,11 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     handleSuccess,
     handleError
   );
+
+  const {
+    mutateAsync: checkPolicyNameAvailability,
+    isPending: isCheckingPolicyName
+  } = useCheckLeavePolicyNameAvailability();
 
   const formik = useFormik<LeavePolicyFormData>({
     initialValues: { ...leavePolicyFormInitialValues, policyType },
@@ -153,7 +166,41 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     }
   };
 
-  const handleNext = async (): Promise<void> => {
+  const isPolicyNameAvailable = async (): Promise<boolean> => {
+    const checkedName = formik.values.policyName.trim();
+    const checkedLeaveType = formik.values.leaveType;
+
+    try {
+      const { isAvailable } = await checkPolicyNameAvailability({
+        name: checkedName,
+        leaveTypeId: checkedLeaveType
+      });
+
+      const currentValues = formikRef.current?.values;
+      const isStale =
+        currentValues?.policyName.trim() !== checkedName ||
+        currentValues?.leaveType !== checkedLeaveType;
+
+      if (isStale) {
+        // The field was edited while the check was in flight, so this answer
+        // is about a name the user has moved on from. Stay put rather than
+        // flagging - or advancing - the wrong name.
+        return false;
+      }
+
+      if (!isAvailable) {
+        showDuplicatePolicyNameError();
+      }
+
+      return isAvailable;
+    } catch {
+      // The check is only a shortcut to an inline error. When it fails, let the
+      // create request run so the backend stays the authority on uniqueness.
+      return true;
+    }
+  };
+
+  const advanceWizard = async (): Promise<void> => {
     const currentStepFields = STEP_FIELDS[activeStep];
     const validationErrors = await formik.validateForm();
     const hasStepError = currentStepFields.some(
@@ -170,6 +217,13 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
       return;
     }
 
+    if (
+      activeStep === LeavePolicyWizardSteps.BASIC_INFO &&
+      !(await isPolicyNameAvailable())
+    ) {
+      return;
+    }
+
     if (isLastStep) {
       if (!isPending) {
         await formik.submitForm();
@@ -178,6 +232,22 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
     }
 
     setActiveStep((previous) => previous + 1);
+  };
+
+  const handleNext = async (): Promise<void> => {
+    // A second click while the availability check is still in flight would run
+    // the whole flow twice. isPending covers the create call itself.
+    if (isAdvancingRef.current) {
+      return;
+    }
+
+    isAdvancingRef.current = true;
+
+    try {
+      await advanceWizard();
+    } finally {
+      isAdvancingRef.current = false;
+    }
   };
 
   const handleEditFromSummary = (step: LeavePolicyWizardSteps): void => {
@@ -232,7 +302,7 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
           icon={!isFirstStep ? <ArrowLeftIcon /> : undefined}
           iconPosition="start"
           onClick={handleBack}
-          disabled={isPending}
+          disabled={isPending || isCheckingPolicyName}
         >
           {translateText([isFirstStep ? "cancelBtnTxt" : "backBtnTxt"])}
         </ButtonV2>
@@ -242,7 +312,7 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
           icon={!isLastStep ? <ArrowRightIcon /> : undefined}
           iconPosition="end"
           onClick={handleNext}
-          disabled={isPending}
+          disabled={isPending || isCheckingPolicyName}
         >
           {isLastStep
             ? translateText([isPending ? "savingBtnTxt" : "createPolicyBtnTxt"])

--- a/frontend/src/community/leave/types/LeavePolicyTypes.ts
+++ b/frontend/src/community/leave/types/LeavePolicyTypes.ts
@@ -137,6 +137,19 @@ export interface LeavePoliciesResponse {
   results: LeavePoliciesPage[];
 }
 
+export interface CheckLeavePolicyNameAvailabilityParams {
+  name: string;
+  leaveTypeId: string;
+}
+
+export interface LeavePolicyNameAvailabilityResult {
+  isAvailable: boolean;
+}
+
+export interface LeavePolicyNameAvailabilityResponse {
+  results: LeavePolicyNameAvailabilityResult[];
+}
+
 export interface LeavePolicyConfigResult {
   isEnabled: boolean;
 }


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
