### PR TITLE
fix: resolve accessibility (a11y) issues on Sign Configurations page

### DIFF
--- a/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
+++ b/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
@@ -299,6 +299,7 @@ const Drawer = (): JSX.Element => {
                     }}
                     aria-expanded={isExpanded}
                     aria-controls={`sub-list-${routeId}`}
+                    aria-label={route?.name}
                   >
                     <ListItemIcon sx={classes.listItemIcon}>
                       {route?.icon && (

--- a/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
+++ b/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
@@ -299,7 +299,7 @@ const Drawer = (): JSX.Element => {
                     }}
                     aria-expanded={isExpanded}
                     aria-controls={`sub-list-${routeId}`}
-                    aria-label={route?.name}
+                    aria-label={!isDrawerExpanded ? route?.name : undefined}
                   >
                     <ListItemIcon sx={classes.listItemIcon}>
                       {route?.icon && (

--- a/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
+++ b/frontend/src/community/common/components/organisms/Drawer/Drawer.tsx
@@ -299,7 +299,7 @@ const Drawer = (): JSX.Element => {
                     }}
                     aria-expanded={isExpanded}
                     aria-controls={`sub-list-${routeId}`}
-                    aria-label={!isDrawerExpanded ? route?.name : undefined}
+                    aria-label={(!isDrawerExpanded && route?.name) || undefined}
                   >
                     <ListItemIcon sx={classes.listItemIcon}>
                       {route?.icon && (


### PR DESCRIPTION
Fixes accessibility violations flagged by axe DevTools on the Sign Configurations page. The collapsible sidebar menu button lost its accessible name when collapsed to icon-only mode, and the Date Format dropdown along with the expiration/reminder day inputs had no accessible name at all. Added aria-label/ariaLabel to each so screen readers can properly announce them.