### PR TITLE
[Fix] Probation end reminder recipients: super admin fallback, pending users, full name

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/model/Employee.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/model/Employee.java
@@ -35,6 +35,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Entity
 @Getter
@@ -186,7 +188,9 @@ public class Employee extends Auditable<String> {
 	private BusinessUnit businessUnit;
 
 	public String getFullName() {
-		return firstName + " " + lastName;
+		return Stream.of(firstName, lastName)
+			.filter(namePart -> namePart != null && !namePart.isBlank())
+			.collect(Collectors.joining(" "));
 	}
 
 }


### PR DESCRIPTION
## Summary

`Employee.getFullName()` concatenates `firstName + " " + lastName`, but `last_name` is nullable. Java string concatenation renders a null as the literal text `null`, so the method returns values like `"testoneguest null"`. This surfaced while fixing the probation end reminder email, where the value is used both in the subject line and in the greeting.

## Changes in this repo (`SkappHQ/skapp`)

- `Employee.getFullName()` now joins only the name parts that are present, so a missing last name yields `"testoneguest"` rather than `"testoneguest null"`. A fully populated name is unchanged.

## Why it is worth fixing rather than working around

The probation change originally carried a private null-safe helper in the enterprise service. That is a near-duplicate of an existing shared method, so the helper was dropped in favour of correcting the method itself — which also fixes the other call sites.

Measured on the dev tenant:

| | count |
|---|---|
| employees with a null `last_name` | 22 |
| of those, still `ACTIVE` or `PENDING` | 11 |

| employee | before | after |
|---|---|---|
| 16 | `testoneguest null` | `testoneguest` |
| 19 | `akila.silvayop null` | `akila.silvayop` |

## Call sites affected

12 in total. Besides the probation email, the visible ones are the leave-policy bulk assign, the AI nudge reporter name, the dashboard super-admin name, the e-signature audit trail `actionVerifiedByName`, and the invoice/project admin and time-log descriptions. In every one of them the previous output for a missing last name was a literal `null` in user-facing text, so the change is a strict improvement rather than a behaviour trade-off.

## Architecture / flow

```mermaid
flowchart LR
    A[Employee.firstName] --> C{part present?}
    B[Employee.lastName] --> C
    C -- yes --> D[join with a single space]
    C -- no --> E[omit the part]
    D --> F[full name]
    E --> F
```

## Exclusions — deliberately NOT in this PR

- **`EmployeeRepositoryImpl.findActiveEmployeesByExactNames`** matches on the SQL expression `lower(concat(concat(first_name, ' '), last_name))`, which does not drop blank parts, so the Java and SQL notions of a full name are no longer identical. No reachable failure was found — a blank `last_name` makes the SQL expression either `NULL` or a trailing-space string that `normalizeName` cannot produce on the request side — so this is latent rather than live. Aligning the two is a separate change with its own testing.
- **No escaping change.** `getFullName()` is interpolated unescaped into email subjects, and escaping it here would render an apostrophe as `&#39;` in the subject line. That is a pre-existing concern in the email layer and needs separate handling for the body and the subject.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Only `Employee.java` is staged in this commit; gitlink updates are done at **deployment time**, not in feature PRs.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit tests | see note | full suite was green at 831 tests before this change; the run after it could not be trusted, see below |
| Formatter (BE only) | yes | pass — `spring-javaformat:validate` and `checkstyle:check` both green |
| tsc + lint (BE only) | n/a | Java repo |
| e2e (Playwright) | yes | pass before this refactor — 3 tests, `emailReminderJobsQueued=6`, `sent: 6, failed: 0` |

**Note on the test run.** `mvn -o package -DskipTests` succeeds, so this compiles cleanly. A full `mvn test` immediately after could not be completed reliably on the authoring machine: the IDE Java language server holds `target/generated-sources` and respawns on kill, leaving a partial `target` and producing `NoClassDefFoundError` and Mockito mocking failures across unrelated tests — classpath corruption, not assertion failures. The last uncorrupted full run was **831 tests, 0 failures** immediately before this refactor. CI should be treated as the authority here; if it reports anything red, it is worth checking against this note before assuming a regression.
