### PR TITLE
[Feat] Add job family and job title to birthday notifications API

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/mapper/PeopleMapper.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/mapper/PeopleMapper.java
@@ -46,6 +46,7 @@ import com.skapp.community.peopleplanner.payload.request.employee.personal.Emplo
 import com.skapp.community.peopleplanner.payload.request.employee.personal.EmployeePersonalFamilyDetailsDto;
 import com.skapp.community.peopleplanner.payload.response.CreateEmployeeResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeAllDataExportResponseDto;
+import com.skapp.community.peopleplanner.payload.response.EmployeeBirthdayResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeDataExportResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeDetailedResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeJobFamilyDto;
@@ -194,6 +195,10 @@ public interface PeopleMapper {
 	EmployeeSignInResponseDto employeeToEmployeeSignInResponseDto(Employee employee);
 
 	EmployeeBasicDetailsResponseDto employeeToEmployeeBasicDetailsResponseDto(Employee employee);
+
+	@Mapping(target = "jobFamily", source = "jobFamily.name")
+	@Mapping(target = "jobTitle", source = "jobTitle.name")
+	EmployeeBirthdayResponseDto employeeToEmployeeBirthdayResponseDto(Employee employee);
 
 	List<HolidayBasicDetailsResponseDto> holidaysToHolidayBasicDetailsResponseDtos(List<Holiday> holidays);
 

--- a/backend/src/main/java/com/skapp/community/peopleplanner/mapper/PeopleMapper.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/mapper/PeopleMapper.java
@@ -200,6 +200,8 @@ public interface PeopleMapper {
 	@Mapping(target = "jobTitle", source = "jobTitle.name")
 	EmployeeBirthdayResponseDto employeeToEmployeeBirthdayResponseDto(Employee employee);
 
+	List<EmployeeBirthdayResponseDto> employeesToEmployeeBirthdayResponseDtos(List<Employee> employees);
+
 	List<HolidayBasicDetailsResponseDto> holidaysToHolidayBasicDetailsResponseDtos(List<Holiday> holidays);
 
 	JobTitleDto jobTitleToJobTitleDto(JobTitle jobTitle);

--- a/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/BirthdayNotificationResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/BirthdayNotificationResponseDto.java
@@ -1,6 +1,5 @@
 package com.skapp.community.peopleplanner.payload.response;
 
-import com.skapp.community.peopleplanner.payload.request.EmployeeBasicDetailsResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,6 +14,6 @@ public class BirthdayNotificationResponseDto {
 
 	private LocalDate lastViewedDate;
 
-	private List<EmployeeBasicDetailsResponseDto> employeeBirthdays;
+	private List<EmployeeBirthdayResponseDto> employeeBirthdays;
 
 }

--- a/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/EmployeeBirthdayResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/EmployeeBirthdayResponseDto.java
@@ -1,21 +1,12 @@
 package com.skapp.community.peopleplanner.payload.response;
 
+import com.skapp.community.peopleplanner.payload.request.EmployeeBasicDetailsResponseDto;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class EmployeeBirthdayResponseDto {
-
-	private Long employeeId;
-
-	private String firstName;
-
-	private String lastName;
-
-	private String middleName;
-
-	private String authPic;
+public class EmployeeBirthdayResponseDto extends EmployeeBasicDetailsResponseDto {
 
 	private String jobFamily;
 

--- a/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/EmployeeBirthdayResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/payload/response/EmployeeBirthdayResponseDto.java
@@ -1,0 +1,24 @@
+package com.skapp.community.peopleplanner.payload.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmployeeBirthdayResponseDto {
+
+	private Long employeeId;
+
+	private String firstName;
+
+	private String lastName;
+
+	private String middleName;
+
+	private String authPic;
+
+	private String jobFamily;
+
+	private String jobTitle;
+
+}

--- a/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
@@ -1674,6 +1674,8 @@ public class EmployeeRepositoryImpl implements EmployeeRepository {
 		root.fetch(Employee_.personalInfo);
 		root.fetch(Employee_.user);
 		root.fetch(Employee_.employeeRole, JoinType.LEFT);
+		root.fetch(Employee_.jobFamily, JoinType.LEFT);
+		root.fetch(Employee_.jobTitle, JoinType.LEFT);
 
 		Join<Employee, EmployeePersonalInfo> personalInfoJoin = root.join(Employee_.personalInfo);
 		Join<Employee, User> userJoin = root.join(Employee_.user);

--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
@@ -1613,9 +1613,8 @@ public class PeopleServiceImpl implements PeopleService {
 			return new ResponseEntityDto(false, new BirthdayNotificationResponseDto(lastViewedDate, List.of()));
 		}
 
-		List<EmployeeBirthdayResponseDto> response = employeesWithBirthdays.stream()
-			.map(peopleMapper::employeeToEmployeeBirthdayResponseDto)
-			.toList();
+		List<EmployeeBirthdayResponseDto> response = peopleMapper
+			.employeesToEmployeeBirthdayResponseDtos(employeesWithBirthdays);
 
 		log.info("getTodayBirthdayNotifications: execution ended");
 		return new ResponseEntityDto(false, new BirthdayNotificationResponseDto(lastViewedDate, response));

--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
@@ -93,6 +93,7 @@ import com.skapp.community.peopleplanner.payload.response.BirthdayNotificationRe
 import com.skapp.community.peopleplanner.payload.response.BirthdayNotificationViewedResponseDto;
 import com.skapp.community.peopleplanner.payload.response.CreateEmployeeResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeAllDataExportResponseDto;
+import com.skapp.community.peopleplanner.payload.response.EmployeeBirthdayResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeBulkErrorResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeBulkResponseDto;
 import com.skapp.community.peopleplanner.payload.response.EmployeeCountDto;
@@ -1612,8 +1613,8 @@ public class PeopleServiceImpl implements PeopleService {
 			return new ResponseEntityDto(false, new BirthdayNotificationResponseDto(lastViewedDate, List.of()));
 		}
 
-		List<EmployeeBasicDetailsResponseDto> response = employeesWithBirthdays.stream()
-			.map(peopleMapper::employeeToEmployeeBasicDetailsResponseDto)
+		List<EmployeeBirthdayResponseDto> response = employeesWithBirthdays.stream()
+			.map(peopleMapper::employeeToEmployeeBirthdayResponseDto)
 			.toList();
 
 		log.info("getTodayBirthdayNotifications: execution ended");

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
@@ -77,6 +77,10 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 
 	private static final String CURRENT_USER_EMAIL = "user1@gmail.com";
 
+	private static final String CURRENT_EMPLOYEE_JOB_FAMILY = "Software Engineer";
+
+	private static final String CURRENT_EMPLOYEE_JOB_TITLE = "Associate";
+
 	private static final Long CURRENT_EMPLOYEE_ID = 1L;
 
 	private static final Long TEAMMATE_EMPLOYEE_ID = 2L;
@@ -256,6 +260,8 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 				.andExpect(jsonPath(birthdayFieldPath(0, "firstName")).value("Employee User One"))
 				.andExpect(jsonPath(birthdayFieldPath(0, "lastName")).value("Lastname One"))
 				.andExpect(jsonPath(birthdayFieldPath(0, "authPic")).value("auth-pic-one.png"))
+				.andExpect(jsonPath(birthdayFieldPath(0, "jobFamily")).value(CURRENT_EMPLOYEE_JOB_FAMILY))
+				.andExpect(jsonPath(birthdayFieldPath(0, "jobTitle")).value(CURRENT_EMPLOYEE_JOB_TITLE))
 				.andExpect(jsonPath(LAST_VIEWED_PATH).value(nullValue()));
 			assertThat(specialNotificationStatusDao.count()).isZero();
 		}
@@ -366,6 +372,24 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 					.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(1))
 					.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()));
 			}
+		}
+
+		@Test
+		@DisplayName("Get today's birthdays when the matching employee has no job family or job title - Returns nulls for both")
+		void getTodayBirthdayNotifications_WithEmployeeWithoutJobFamilyAndJobTitle_ReturnsNullsForBoth()
+				throws Exception {
+			seedConfig(true, false, false);
+			giveBirthdayOn(CURRENT_EMPLOYEE_ID, today);
+			mutateEmployee(CURRENT_EMPLOYEE_ID, employee -> {
+				employee.setJobFamily(null);
+				employee.setJobTitle(null);
+			});
+
+			assertSuccessful(performGetTodayRequest(currentUserToken))
+				.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(1))
+				.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()))
+				.andExpect(jsonPath(birthdayFieldPath(0, "jobFamily")).value(nullValue()))
+				.andExpect(jsonPath(birthdayFieldPath(0, "jobTitle")).value(nullValue()));
 		}
 
 	}


### PR DESCRIPTION
## Summary

Adds an employee's job family and job title to the "today's birthday notifications" API response, so consumers can display an employee's role alongside their birthday without a follow-up lookup.

## Changes in this repo (`SkappHQ/skapp`)

- Added `EmployeeBirthdayResponseDto` (`employeeId`, `firstName`, `lastName`, `middleName`, `authPic`, `jobFamily`, `jobTitle`) as the element type of `BirthdayNotificationResponseDto.employeeBirthdays`, replacing the shared `EmployeeBasicDetailsResponseDto` for this one response so the ~20 other consumers of that shared DTO are unaffected.
- Added `PeopleMapper.employeeToEmployeeBirthdayResponseDto`, mapping `jobFamily.name` / `jobTitle.name` the same way `employeeToEmployeeSignInResponseDto` already does.
- `PeopleServiceImpl.getTodayBirthdayNotifications` now maps through the new method.
- `EmployeeRepositoryImpl.findEmployeeBirthdaysOnByViewerAndScope` fetch-joins `Employee_.jobFamily` and `Employee_.jobTitle` (`LEFT`) so both associations come back in the existing query instead of triggering per-employee lazy loads.
- Extended `PeopleBirthdayNotificationControllerIntegrationTest` to assert `jobFamily`/`jobTitle` on the existing SELF-scope case, and added a case covering an employee with neither association set (both fields serialize as `null`).

## Architecture / flow

```mermaid
flowchart LR
    A[GET /v1/people/birthday-notifications/today] --> B[PeopleController]
    B --> C[PeopleServiceImpl.getTodayBirthdayNotifications]
    C --> D[EmployeeRepositoryImpl\nCriteria query + LEFT JOIN FETCH\njobFamily, jobTitle]
    D --> E[PeopleMapper.employeeToEmployeeBirthdayResponseDto]
    E --> F[EmployeeBirthdayResponseDto\n+ jobFamily, jobTitle]
```

## Exclusions — deliberately NOT in this PR

- The frontend `EmployeeBirthdayType` and birthday modal components are unchanged. They ignore unknown response fields today, so nothing breaks, but rendering job family/title in the birthday modals is a separate UI decision this PR doesn't make.
- `EmployeeBasicDetailsResponseDto` (the shared DTO used by ~20 other responses) is untouched — a new, narrower DTO was added instead of widening a shared one.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** (`backend/src/main/java/com/skapp/enterprise`, `backend/src/main/resources/config`) are intentionally excluded. Gitlink updates are done at **deployment time**, not in feature PRs.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit / integration tests (`PeopleBirthdayNotificationControllerIntegrationTest`) | yes | pass (15/15) |
| Formatter (spring-javaformat validate) | yes | pass |
| Checkstyle | yes | pass |
| e2e (Playwright) | no | No existing birthday e2e spec and no frontend change in this PR; the additive API field is fully covered by the integration tests above |
