### PR TITLE
chore: bump skapp-ui to 1.1.2-beta.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/base": "^5.0.0-beta.58",
         "@mui/x-date-pickers": "^7.29.1",
         "@next/third-parties": "^15.3.1",
-        "@rootcodelabs/skapp-ui": "1.1.1",
+        "@rootcodelabs/skapp-ui": "1.1.2-beta.1",
         "@tailwindcss/postcss": "^4.2.1",
         "@tanstack/react-query": "^5.74.4",
         "@tanstack/react-query-devtools": "^5.74.6",
@@ -7651,9 +7651,9 @@
       "peer": true
     },
     "node_modules/@rootcodelabs/skapp-ui": {
-      "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@rootcodelabs/skapp-ui/1.1.1/714560ebee6d77e85cd3d031281e448712906691",
-      "integrity": "sha512-JbS6bpe+JZKVXPNBlK9CchvfCeKp8QUsAvBBERTg4GQqINq/1srhcFRFVGV5XPdP+vzz27cIRmWuf6bKY+vrpA==",
+      "version": "1.1.2-beta.1",
+      "resolved": "https://npm.pkg.github.com/download/@rootcodelabs/skapp-ui/1.1.2-beta.1/be45a74dcd9f21f08cec729a332a91d91a207ae6",
+      "integrity": "sha512-1eeuI/z0D2NYoXsRgfP8QgzJJyc20DEla0GIttiEqitCVbvfJu413qijw3IaXHoY6KZjaNMjbcHs1HPEOUGn9w==",
       "license": "ISC",
       "peerDependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "@mui/base": "^5.0.0-beta.58",
     "@mui/x-date-pickers": "^7.29.1",
     "@next/third-parties": "^15.3.1",
-    "@rootcodelabs/skapp-ui": "1.1.1",
+    "@rootcodelabs/skapp-ui": "1.1.2-beta.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@tanstack/react-query": "^5.74.4",
     "@tanstack/react-query-devtools": "^5.74.6",


### PR DESCRIPTION
## PR checklist

### Summary

- Bump `@rootcodelabs/skapp-ui` to `1.1.2-beta.1`

### How to test

1. `npm i` in `skapp/frontend` and verify the app builds/runs with the new UI library beta.

### Project Checklist

- [ ] Changes build without any errors

#### Other

- [x] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title