### PR TITLE
CRM deal list-view schema: migrations, baseline DDL & JPA entities

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/model/UserSettings.java
+++ b/backend/src/main/java/com/skapp/community/common/model/UserSettings.java
@@ -38,4 +38,8 @@ public class UserSettings {
 	@Convert(converter = JsonTypeConverter.class)
 	private JsonNode notifications;
 
+	@Column(name = "crm_deal_list_view", columnDefinition = "json")
+	@Convert(converter = JsonTypeConverter.class)
+	private JsonNode crmDealListView;
+
 }

--- a/backend/src/main/java/com/skapp/community/common/model/UserSettings.java
+++ b/backend/src/main/java/com/skapp/community/common/model/UserSettings.java
@@ -38,7 +38,7 @@ public class UserSettings {
 	@Convert(converter = JsonTypeConverter.class)
 	private JsonNode notifications;
 
-	@Column(name = "crm_deal_list_view", columnDefinition = "json")
+	@Column(name = "crm_deal_list_view")
 	@Convert(converter = JsonTypeConverter.class)
 	private JsonNode crmDealListView;
 

--- a/backend/src/main/java/com/skapp/community/crmplanner/model/CrmDealOrderIndex.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/model/CrmDealOrderIndex.java
@@ -1,0 +1,37 @@
+package com.skapp.community.crmplanner.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "crm_deal_order_index")
+public class CrmDealOrderIndex {
+
+	@Id
+	@Column(name = "deal_id", nullable = false, updatable = false)
+	private Long dealId;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@MapsId
+	@JoinColumn(name = "deal_id")
+	private CrmDeal deal;
+
+	@Column(name = "board", nullable = false)
+	private String board;
+
+	@Column(name = "list", nullable = false)
+	private String list;
+
+}

--- a/backend/src/main/java/com/skapp/community/crmplanner/model/CrmDealOrderIndex.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/model/CrmDealOrderIndex.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -20,11 +19,7 @@ import lombok.Setter;
 public class CrmDealOrderIndex {
 
 	@Id
-	@Column(name = "deal_id", nullable = false, updatable = false)
-	private Long dealId;
-
 	@OneToOne(fetch = FetchType.LAZY)
-	@MapsId
 	@JoinColumn(name = "deal_id")
 	private CrmDeal deal;
 

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
@@ -528,8 +528,9 @@ CREATE TABLE IF NOT EXISTS `rule_property`
 
 CREATE TABLE IF NOT EXISTS `user_settings`
 (
-    `user_id`       bigint NOT NULL,
-    `notifications` json DEFAULT NULL,
+    `user_id`            bigint NOT NULL,
+    `notifications`      json DEFAULT NULL,
+    `crm_deal_list_view` json DEFAULT NULL,
     PRIMARY KEY (`user_id`),
     CONSTRAINT `FK_user_settings_user_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`)
 ) ENGINE = InnoDB;
@@ -676,6 +677,15 @@ CREATE TABLE IF NOT EXISTS `crm_deal`
     CONSTRAINT `FK_crm_deal_employee_owner_id` FOREIGN KEY (`owner_id`) REFERENCES `employee` (`employee_id`)
 ) ENGINE = InnoDB;
 
+CREATE TABLE IF NOT EXISTS `crm_deal_order_index`
+(
+    `deal_id` bigint                                         NOT NULL,
+    `board`   text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    `list`    text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    PRIMARY KEY (`deal_id`),
+    CONSTRAINT `FK_crm_deal_order_index_crm_deal_deal_id` FOREIGN KEY (`deal_id`) REFERENCES `crm_deal` (`id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
 CREATE TABLE IF NOT EXISTS `crm_task`
 (
     `id`                 bigint  NOT NULL AUTO_INCREMENT,
@@ -703,6 +713,7 @@ CREATE TABLE IF NOT EXISTS `crm_task`
 ) ENGINE = InnoDB;
 
 -- rollback drop table crm_task;
+-- rollback drop table crm_deal_order_index;
 -- rollback drop table crm_deal;
 -- rollback drop table crm_deal_stage;
 -- rollback drop table crm_contact;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
@@ -530,7 +530,7 @@ CREATE TABLE IF NOT EXISTS `user_settings`
 (
     `user_id`            bigint NOT NULL,
     `notifications`      json DEFAULT NULL,
-    `crm_deal_list_view` json DEFAULT NULL,
+    `crm_deal_list_view` json,
     PRIMARY KEY (`user_id`),
     CONSTRAINT `FK_user_settings_user_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`)
 ) ENGINE = InnoDB;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
@@ -683,7 +683,7 @@ CREATE TABLE IF NOT EXISTS `crm_deal_order_index`
     `board`   text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
     `list`    text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
     PRIMARY KEY (`deal_id`),
-    CONSTRAINT `FK_crm_deal_order_index_crm_deal_deal_id` FOREIGN KEY (`deal_id`) REFERENCES `crm_deal` (`id`) ON DELETE CASCADE
+    CONSTRAINT `FK_crm_deal_order_index_crm_deal_deal_id` FOREIGN KEY (`deal_id`) REFERENCES `crm_deal` (`id`)
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `crm_task`


### PR DESCRIPTION
## Summary
Migration-phase change for the CRM deal table-view feature: schema + its JPA entity mappings.

**Baseline DDL** (`common-ddl-script-v1-create-tables.sql`)
- `crm_deal_order_index` table — per-view (`board`/`list`) fractional row ordering, `utf8mb4_bin`, FK to `crm_deal` `ON DELETE CASCADE`.
- `user_settings.crm_deal_list_view` JSON column — per-user column order/visibility + active sort.

**JPA entities**
- `CrmDealOrderIndex` — maps `crm_deal_order_index` (`@MapsId` 1:1 with `CrmDeal`).
- `UserSettings.crmDealListView` — maps the new JSON column.

## Related
- Liquibase migrations: rootcodelabs/skapp-migrations#214
- Config API (uses `UserSettings.crmDealListView`): SkappHQ/skapp#1831
- Row ordering / reorder / sorting (uses `CrmDealOrderIndex`): separate PR
- The backend code PRs depend on the entities here, so this PR merges first.