### PR TITLE
[Fix] Use placeholder avatar for the work location "All Employees" chip

### DIFF
--- a/frontend/src/community/configurations/components/molecules/WorkLocationEmployeeSelector/WorkLocationEmployeeSelector.tsx
+++ b/frontend/src/community/configurations/components/molecules/WorkLocationEmployeeSelector/WorkLocationEmployeeSelector.tsx
@@ -293,7 +293,8 @@ const WorkLocationEmployeeSelector = ({
           avatarProps={{
             id: `${idPrefix}-all-employees`,
             firstName: allEmployeesLabel,
-            size: "sm"
+            size: "sm",
+            isPlaceholder: true
           }}
           label={allEmployeesLabel}
         />


### PR DESCRIPTION
## Summary

The **All Employees** chip in the work location employee selector is not a person, but it was rendering through the same avatar path as real employees — so it showed an initial letter derived from its own label ("A") in the avatar circle. This switches that one chip to the skapp-ui `Avatar` placeholder treatment (`isPlaceholder: true`), which renders the design system's `AvatarIcon` silhouette instead of initials. Employee chips are untouched and keep their photos/initials.
