### PR TITLE
[Fix]: 3005 Clear Business Unit form error on edit

### DIFF
--- a/frontend/src/community/configurations/components/molecules/BusinessUnitFormModal/BusinessUnitFormModal.tsx
+++ b/frontend/src/community/configurations/components/molecules/BusinessUnitFormModal/BusinessUnitFormModal.tsx
@@ -6,7 +6,7 @@ import {
   TextArea
 } from "@rootcodelabs/skapp-ui";
 import { useFormik } from "formik";
-import { FC } from "react";
+import { ChangeEvent, FC } from "react";
 
 import {
   useCreateBusinessUnit,
@@ -113,6 +113,15 @@ const BusinessUnitFormModal: FC<Props> = ({
     onSubmit: handleSubmit
   });
 
+  const handleFieldChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    if (formik.errors[e.target.name as keyof BusinessUnitFormValues]) {
+      formik.setFieldError(e.target.name, undefined);
+    }
+    formik.handleChange(e);
+  };
+
   const handleClose = () => {
     if (isPending) return;
     formik.resetForm();
@@ -135,7 +144,7 @@ const BusinessUnitFormModal: FC<Props> = ({
             label={translateText(["form", "nameLabel"])}
             name="name"
             value={formik.values.name}
-            onChange={formik.handleChange}
+            onChange={handleFieldChange}
             onBlur={formik.handleBlur}
             placeholder={translateText(["form", "namePlaceholder"])}
             errorMessage={formik.errors.name}
@@ -147,7 +156,7 @@ const BusinessUnitFormModal: FC<Props> = ({
             label={translateText(["form", "descriptionLabel"])}
             name="description"
             value={formik.values.description}
-            onChange={formik.handleChange}
+            onChange={handleFieldChange}
             onBlur={formik.handleBlur}
             placeholder={translateText(["form", "descriptionPlaceholder"])}
             errorMessage={formik.errors.description}


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/3005)

### Summary

- On the Create/Edit Business Unit form, a validation error (e.g. duplicate name) stayed on screen even after the user corrected the input, because `validateOnChange` is off and the error only re-evaluated on blur/submit.
- Added a `handleFieldChange` wrapper that clears a field's error via `setFieldError` as soon as the user edits it, then delegates to `formik.handleChange`. Wired it to both the name `InputField` and description `TextArea`.
- Keeps the existing `validateOnChange: false` / `validateOnBlur: true` behaviour so validation still runs on blur.

### How to test

1. Log in as Super Admin / People Admin and open Business Unit Configuration.
2. Click Create, enter an existing Business Unit name, and blur/submit to trigger the validation error.
3. Start editing the name to a valid value.
4. The error message should clear immediately as you type (previously it stayed until the next blur).

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-