### PR TITLE
fix: re-invite-pending-employee-toast-title

### DIFF
--- a/frontend/src/community/common/assets/languages/english/peopleModule.json
+++ b/frontend/src/community/common/assets/languages/english/peopleModule.json
@@ -575,7 +575,7 @@
       "employeeAddErrorToastTitle": "Oops! Something went wrong",
       "employeeAddErrorToastDescription": "Failed to add the resource. Please try again.",
       "areYouSureModalTitle": "Are you sure?",
-      "reInvitationForOneEmployeeSuccessfulToastTitle": "Reinvitated Successfully",
+      "reInvitationForOneEmployeeSuccessfulToastTitle": "Reinvited Successfully",
       "reInvitationForOneEmployeeSuccessfulToastDescription": "Reinvitation sent for the employee successfully",
       "addFullProfile": "Add Full Profile",
       "save": "Save"


### PR DESCRIPTION
renamed to the miss spelled to reinvited propperly