### PR TITLE
fix: Block clock-in for pending leave requests when "Clock in on leave days" is disabled

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
@@ -5,6 +5,7 @@ import com.skapp.community.leaveplanner.model.LeaveRequest;
 import com.skapp.community.leaveplanner.payload.EmployeeLeaveHistoryFilterDto;
 import com.skapp.community.leaveplanner.payload.LeaveRequestFilterDto;
 import com.skapp.community.leaveplanner.payload.TeamLeaveHistoryFilterDto;
+import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.payload.request.EmployeesOnLeavePeriodFilterDto;
 import com.skapp.community.leaveplanner.payload.response.EmployeeLeaveRequestReportExportDto;
 import com.skapp.community.leaveplanner.payload.response.EmployeeLeaveRequestReportQueryDto;
@@ -32,7 +33,8 @@ public interface LeaveRequestRepository {
 
 	List<LeaveRequest> findAllLeaveRequestsByDateRange(LeaveRequestFilterDto leaveRequestFilterDto);
 
-	List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId);
+	List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId,
+			List<LeaveRequestStatus> statuses);
 
 	List<LeaveRequest> findLeaveRequestAvailabilityForGivenDate(LocalDate date, Long employeeId);
 

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
@@ -5,7 +5,6 @@ import com.skapp.community.leaveplanner.model.LeaveRequest;
 import com.skapp.community.leaveplanner.payload.EmployeeLeaveHistoryFilterDto;
 import com.skapp.community.leaveplanner.payload.LeaveRequestFilterDto;
 import com.skapp.community.leaveplanner.payload.TeamLeaveHistoryFilterDto;
-import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.payload.request.EmployeesOnLeavePeriodFilterDto;
 import com.skapp.community.leaveplanner.payload.response.EmployeeLeaveRequestReportExportDto;
 import com.skapp.community.leaveplanner.payload.response.EmployeeLeaveRequestReportQueryDto;
@@ -33,8 +32,9 @@ public interface LeaveRequestRepository {
 
 	List<LeaveRequest> findAllLeaveRequestsByDateRange(LeaveRequestFilterDto leaveRequestFilterDto);
 
-	List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId,
-			List<LeaveRequestStatus> statuses);
+	List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId);
+
+	List<LeaveRequest> findPendingAndApprovedLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId);
 
 	List<LeaveRequest> findLeaveRequestAvailabilityForGivenDate(LocalDate date, Long employeeId);
 

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -334,7 +334,8 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 	}
 
 	@Override
-	public List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId) {
+	public List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId,
+			List<LeaveRequestStatus> statuses) {
 		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
 		Root<LeaveRequest> leaveRequest = criteriaQuery.from(LeaveRequest.class);
@@ -342,9 +343,7 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		Join<LeaveRequest, Employee> employee = leaveRequest.join(LeaveRequest_.employee);
 
 		Predicate employeePredicate = criteriaBuilder.equal(employee.get(Employee_.employeeId), employeeId);
-		Predicate statusPredicate = criteriaBuilder.or(
-				criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status), LeaveRequestStatus.PENDING),
-				criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status), LeaveRequestStatus.APPROVED));
+		Predicate statusPredicate = leaveRequest.get(LeaveRequest_.status).in(statuses);
 
 		Predicate datePredicate = criteriaBuilder.between(criteriaBuilder.literal(currentDate),
 				leaveRequest.get(LeaveRequest_.startDate), leaveRequest.get(LeaveRequest_.endDate));

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -334,8 +334,7 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 	}
 
 	@Override
-	public List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId,
-			List<LeaveRequestStatus> statuses) {
+	public List<LeaveRequest> findLeaveRequestsForTodayByUser(LocalDate currentDate, Long employeeId) {
 		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
 		Root<LeaveRequest> leaveRequest = criteriaQuery.from(LeaveRequest.class);
@@ -343,7 +342,31 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		Join<LeaveRequest, Employee> employee = leaveRequest.join(LeaveRequest_.employee);
 
 		Predicate employeePredicate = criteriaBuilder.equal(employee.get(Employee_.employeeId), employeeId);
-		Predicate statusPredicate = leaveRequest.get(LeaveRequest_.status).in(statuses);
+		Predicate statusPredicate = criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status),
+				LeaveRequestStatus.APPROVED);
+
+		Predicate datePredicate = criteriaBuilder.between(criteriaBuilder.literal(currentDate),
+				leaveRequest.get(LeaveRequest_.startDate), leaveRequest.get(LeaveRequest_.endDate));
+
+		criteriaQuery.where(criteriaBuilder.and(employeePredicate, statusPredicate, datePredicate));
+
+		TypedQuery<LeaveRequest> query = entityManager.createQuery(criteriaQuery);
+
+		return query.getResultList();
+	}
+
+	@Override
+	public List<LeaveRequest> findPendingAndApprovedLeaveRequestsForTodayByUser(LocalDate currentDate,
+			Long employeeId) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
+		Root<LeaveRequest> leaveRequest = criteriaQuery.from(LeaveRequest.class);
+
+		Join<LeaveRequest, Employee> employee = leaveRequest.join(LeaveRequest_.employee);
+
+		Predicate employeePredicate = criteriaBuilder.equal(employee.get(Employee_.employeeId), employeeId);
+		Predicate statusPredicate = leaveRequest.get(LeaveRequest_.status)
+			.in(LeaveRequestStatus.PENDING, LeaveRequestStatus.APPROVED);
 
 		Predicate datePredicate = criteriaBuilder.between(criteriaBuilder.literal(currentDate),
 				leaveRequest.get(LeaveRequest_.startDate), leaveRequest.get(LeaveRequest_.endDate));

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -342,8 +342,9 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		Join<LeaveRequest, Employee> employee = leaveRequest.join(LeaveRequest_.employee);
 
 		Predicate employeePredicate = criteriaBuilder.equal(employee.get(Employee_.employeeId), employeeId);
-		Predicate statusPredicate = criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status),
-				LeaveRequestStatus.APPROVED);
+		Predicate statusPredicate = criteriaBuilder.or(
+				criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status), LeaveRequestStatus.PENDING),
+				criteriaBuilder.equal(leaveRequest.get(LeaveRequest_.status), LeaveRequestStatus.APPROVED));
 
 		Predicate datePredicate = criteriaBuilder.between(criteriaBuilder.literal(currentDate),
 				leaveRequest.get(LeaveRequest_.startDate), leaveRequest.get(LeaveRequest_.endDate));

--- a/backend/src/main/java/com/skapp/community/timeplanner/payload/response/ActiveTimeSlotResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/payload/response/ActiveTimeSlotResponseDto.java
@@ -12,6 +12,8 @@ public class ActiveTimeSlotResponseDto {
 
 	private TimeRecordActionTypes periodType;
 
+	private boolean leavePending;
+
 	private LocalDateTime starTime;
 
 	private float workHours;

--- a/backend/src/main/java/com/skapp/community/timeplanner/payload/response/ActiveTimeSlotResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/payload/response/ActiveTimeSlotResponseDto.java
@@ -12,7 +12,7 @@ public class ActiveTimeSlotResponseDto {
 
 	private TimeRecordActionTypes periodType;
 
-	private boolean leavePending;
+	private Boolean isLeavePending;
 
 	private LocalDateTime starTime;
 

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeAnalyticsServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeAnalyticsServiceImpl.java
@@ -12,7 +12,6 @@ import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.leaveplanner.mapper.LeaveMapper;
 import com.skapp.community.leaveplanner.model.LeaveRequest;
 import com.skapp.community.leaveplanner.repository.LeaveRequestDao;
-import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.type.LeaveState;
 import com.skapp.community.peopleplanner.mapper.PeopleMapper;
 import com.skapp.community.peopleplanner.model.Employee;
@@ -277,8 +276,8 @@ public class TimeAnalyticsServiceImpl implements TimeAnalyticsService {
 			return Optional.empty();
 		}
 
-		List<LeaveRequest> leaveRequestsList = leaveRequestDao.findLeaveRequestsForTodayByUser(
-				DateTimeUtils.getCurrentUtcDate(), employee.getEmployeeId(), List.of(LeaveRequestStatus.APPROVED));
+		List<LeaveRequest> leaveRequestsList = leaveRequestDao
+			.findLeaveRequestsForTodayByUser(DateTimeUtils.getCurrentUtcDate(), employee.getEmployeeId());
 
 		boolean clockInOnLeaveDaysStatus = attendanceConfigService
 			.getAttendanceConfigByType(AttendanceConfigType.CLOCK_IN_ON_LEAVE_DAYS);

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeAnalyticsServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeAnalyticsServiceImpl.java
@@ -12,6 +12,7 @@ import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.leaveplanner.mapper.LeaveMapper;
 import com.skapp.community.leaveplanner.model.LeaveRequest;
 import com.skapp.community.leaveplanner.repository.LeaveRequestDao;
+import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.type.LeaveState;
 import com.skapp.community.peopleplanner.mapper.PeopleMapper;
 import com.skapp.community.peopleplanner.model.Employee;
@@ -276,8 +277,8 @@ public class TimeAnalyticsServiceImpl implements TimeAnalyticsService {
 			return Optional.empty();
 		}
 
-		List<LeaveRequest> leaveRequestsList = leaveRequestDao
-			.findLeaveRequestsForTodayByUser(DateTimeUtils.getCurrentUtcDate(), employee.getEmployeeId());
+		List<LeaveRequest> leaveRequestsList = leaveRequestDao.findLeaveRequestsForTodayByUser(
+				DateTimeUtils.getCurrentUtcDate(), employee.getEmployeeId(), List.of(LeaveRequestStatus.APPROVED));
 
 		boolean clockInOnLeaveDaysStatus = attendanceConfigService
 			.getAttendanceConfigByType(AttendanceConfigType.CLOCK_IN_ON_LEAVE_DAYS);

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
@@ -1199,8 +1199,8 @@ public class TimeServiceImpl implements TimeService {
 			float morningHours = hoursMap.get(CommonConstants.DEFAULT_TIME_CONFIG_VALUE_MORNING);
 			float eveningHours = hoursMap.get(CommonConstants.DEFAULT_TIME_CONFIG_VALUE_EVENING);
 
-			List<LeaveRequest> leaveRequestsList = leaveRequestDao
-				.findPendingAndApprovedLeaveRequestsForTodayByUser(currentDate, currentUser.getEmployee().getEmployeeId());
+			List<LeaveRequest> leaveRequestsList = leaveRequestDao.findPendingAndApprovedLeaveRequestsForTodayByUser(
+					currentDate, currentUser.getEmployee().getEmployeeId());
 
 			ResponseEntityDto activeTimeSlotResponseDto1 = getAllActiveSlotsNoLeaveDay(currentDayConfig, morningHours,
 					eveningHours, leaveRequestsList);

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
@@ -1199,9 +1199,8 @@ public class TimeServiceImpl implements TimeService {
 			float morningHours = hoursMap.get(CommonConstants.DEFAULT_TIME_CONFIG_VALUE_MORNING);
 			float eveningHours = hoursMap.get(CommonConstants.DEFAULT_TIME_CONFIG_VALUE_EVENING);
 
-			List<LeaveRequest> leaveRequestsList = leaveRequestDao.findLeaveRequestsForTodayByUser(currentDate,
-					currentUser.getEmployee().getEmployeeId(),
-					List.of(LeaveRequestStatus.PENDING, LeaveRequestStatus.APPROVED));
+			List<LeaveRequest> leaveRequestsList = leaveRequestDao
+				.findPendingAndApprovedLeaveRequestsForTodayByUser(currentDate, currentUser.getEmployee().getEmployeeId());
 
 			ResponseEntityDto activeTimeSlotResponseDto1 = getAllActiveSlotsNoLeaveDay(currentDayConfig, morningHours,
 					eveningHours, leaveRequestsList);

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
@@ -1265,7 +1265,7 @@ public class TimeServiceImpl implements TimeService {
 				if (isEveningLeave || isMorningLeave || isFullDayLeave) {
 					ActiveTimeSlotResponseDto activeTimeSlotResponseDto = new ActiveTimeSlotResponseDto();
 					activeTimeSlotResponseDto.setPeriodType(TimeRecordActionTypes.LEAVE_DAY);
-					activeTimeSlotResponseDto.setLeavePending(leaveRequest.getStatus() == LeaveRequestStatus.PENDING);
+					activeTimeSlotResponseDto.setIsLeavePending(leaveRequest.getStatus() == LeaveRequestStatus.PENDING);
 					return new ResponseEntityDto(false, activeTimeSlotResponseDto);
 				}
 			}

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeServiceImpl.java
@@ -1200,7 +1200,8 @@ public class TimeServiceImpl implements TimeService {
 			float eveningHours = hoursMap.get(CommonConstants.DEFAULT_TIME_CONFIG_VALUE_EVENING);
 
 			List<LeaveRequest> leaveRequestsList = leaveRequestDao.findLeaveRequestsForTodayByUser(currentDate,
-					currentUser.getEmployee().getEmployeeId());
+					currentUser.getEmployee().getEmployeeId(),
+					List.of(LeaveRequestStatus.PENDING, LeaveRequestStatus.APPROVED));
 
 			ResponseEntityDto activeTimeSlotResponseDto1 = getAllActiveSlotsNoLeaveDay(currentDayConfig, morningHours,
 					eveningHours, leaveRequestsList);
@@ -1265,6 +1266,7 @@ public class TimeServiceImpl implements TimeService {
 				if (isEveningLeave || isMorningLeave || isFullDayLeave) {
 					ActiveTimeSlotResponseDto activeTimeSlotResponseDto = new ActiveTimeSlotResponseDto();
 					activeTimeSlotResponseDto.setPeriodType(TimeRecordActionTypes.LEAVE_DAY);
+					activeTimeSlotResponseDto.setLeavePending(leaveRequest.getStatus() == LeaveRequestStatus.PENDING);
 					return new ResponseEntityDto(false, activeTimeSlotResponseDto);
 				}
 			}

--- a/frontend/src/community/attendance/api/AttendanceApi.ts
+++ b/frontend/src/community/attendance/api/AttendanceApi.ts
@@ -76,6 +76,7 @@ export const useGetEmployeeStatus = () => {
         setAttendanceParams("slotStartTime", params?.starTime);
         setAttendanceParams("breakHours", params?.breakHours);
         setAttendanceParams("workHours", params?.workHours);
+        setAttendanceParams("leavePending", params?.leavePending);
       } else {
         setAttendanceParams("slotType", AttendanceSlotType.READY);
       }

--- a/frontend/src/community/attendance/api/AttendanceApi.ts
+++ b/frontend/src/community/attendance/api/AttendanceApi.ts
@@ -76,7 +76,7 @@ export const useGetEmployeeStatus = () => {
         setAttendanceParams("slotStartTime", params?.starTime);
         setAttendanceParams("breakHours", params?.breakHours);
         setAttendanceParams("workHours", params?.workHours);
-        setAttendanceParams("leavePending", params?.leavePending);
+        setAttendanceParams("isLeavePending", params?.isLeavePending);
       } else {
         setAttendanceParams("slotType", AttendanceSlotType.READY);
       }

--- a/frontend/src/community/attendance/components/molecules/ClockWidget/ClockWidget.tsx
+++ b/frontend/src/community/attendance/components/molecules/ClockWidget/ClockWidget.tsx
@@ -35,7 +35,7 @@ const ClockWidget = (): JSX.Element => {
     setIsAttendanceModalOpen
   } = useAttendanceStore((state) => state);
   const status = attendanceParams.slotType;
-  const isLeavePending = attendanceParams.leavePending;
+  const isLeavePending = attendanceParams.isLeavePending;
 
   const { refetch: getEmployeeStatusRefetch } = useGetEmployeeStatus();
   const { data: timeConfigData } = useDefaultCapacity();

--- a/frontend/src/community/attendance/components/molecules/ClockWidget/ClockWidget.tsx
+++ b/frontend/src/community/attendance/components/molecules/ClockWidget/ClockWidget.tsx
@@ -35,6 +35,7 @@ const ClockWidget = (): JSX.Element => {
     setIsAttendanceModalOpen
   } = useAttendanceStore((state) => state);
   const status = attendanceParams.slotType;
+  const isLeavePending = attendanceParams.leavePending;
 
   const { refetch: getEmployeeStatusRefetch } = useGetEmployeeStatus();
   const { data: timeConfigData } = useDefaultCapacity();
@@ -82,11 +83,13 @@ const ClockWidget = (): JSX.Element => {
       case AttendanceSlotType.NON_WORKING_DAY:
         return translateText(["notAllowedToClockInOnNonWorkingDaysTooltip"]);
       case AttendanceSlotType.LEAVE_DAY:
-        return translateText(["notAllowedToClockInOnLeaveDaysTooltip"]);
+        return isLeavePending
+          ? translateText(["notAllowedToClockInOnPendingLeaveDaysTooltip"])
+          : translateText(["notAllowedToClockInOnLeaveDaysTooltip"]);
       default:
         return "";
     }
-  }, [isDisabled, status, translateText, hasHoveredAfterEnd]);
+  }, [isDisabled, status, translateText, hasHoveredAfterEnd, isLeavePending]);
 
   const showTimer = useMemo(
     () =>

--- a/frontend/src/community/attendance/store/slices/attendanceSlice.ts
+++ b/frontend/src/community/attendance/store/slices/attendanceSlice.ts
@@ -11,7 +11,7 @@ const attendanceParams: attendanceStatusTypes = {
   slotStartTime: null,
   breakHours: null,
   workHours: null,
-  leavePending: false
+  isLeavePending: false
 };
 
 const attendanceLeaveStatus: attendanceLeaveStatusTypes = {

--- a/frontend/src/community/attendance/store/slices/attendanceSlice.ts
+++ b/frontend/src/community/attendance/store/slices/attendanceSlice.ts
@@ -10,7 +10,8 @@ const attendanceParams: attendanceStatusTypes = {
   slotType: AttendanceSlotType.READY,
   slotStartTime: null,
   breakHours: null,
-  workHours: null
+  workHours: null,
+  leavePending: false
 };
 
 const attendanceLeaveStatus: attendanceLeaveStatusTypes = {

--- a/frontend/src/community/attendance/types/attendanceTypes.ts
+++ b/frontend/src/community/attendance/types/attendanceTypes.ts
@@ -29,7 +29,7 @@ export interface attendanceStatusTypes {
   slotStartTime: string | null;
   breakHours: number | null;
   workHours: number | null;
-  leavePending?: boolean;
+  isLeavePending?: boolean;
 }
 
 export interface attendanceLeaveStatusTypes {

--- a/frontend/src/community/attendance/types/attendanceTypes.ts
+++ b/frontend/src/community/attendance/types/attendanceTypes.ts
@@ -29,6 +29,7 @@ export interface attendanceStatusTypes {
   slotStartTime: string | null;
   breakHours: number | null;
   workHours: number | null;
+  leavePending?: boolean;
 }
 
 export interface attendanceLeaveStatusTypes {

--- a/frontend/src/community/common/assets/languages/english/attendanceModule.json
+++ b/frontend/src/community/common/assets/languages/english/attendanceModule.json
@@ -243,6 +243,7 @@
     "notAllowedToClockInOnNonWorkingDaysTooltip": "You are not allowed to clock in on non-working days",
     "notAllowedToClockInOnHolidaysTooltip": "You are not allowed to clock in on company holidays",
     "notAllowedToClockInOnLeaveDaysTooltip": "You are not allowed to clock in on leave days",
+    "notAllowedToClockInOnPendingLeaveDaysTooltip": "Clock-in is blocked while your leave request for today is awaiting approval",
     "clockInConfirmation": "Clock in confirmation",
     "closeButton": "Close Button",
     "clockInConfirmationDescription": "You have applied for a leave today. Are you sure you want to clock in?",


### PR DESCRIPTION
Fixes clock-in bypass for pending leave requests. The backend query behind the "Clock in on leave days" restriction only checked for APPROVED leave, so employees with a pending request could still clock in via the warning modal. Now it checks both PENDING and APPROVED, matching the leave-availability check already used for the warning modal, so the clock-in button is correctly disabled with a tooltip in both cases.