### PR TITLE
[Fix]: 2857 Persist active profile tab in URL

### DIFF
--- a/frontend/src/community/common/utils/commonUtil.ts
+++ b/frontend/src/community/common/utils/commonUtil.ts
@@ -627,7 +627,7 @@ export const updateUrlQueryParam = (
   key: string,
   value: string | null
 ): void => {
-  if (typeof globalThis.window === "undefined") {
+  if (globalThis.window === undefined) {
     return;
   }
 

--- a/frontend/src/community/common/utils/commonUtil.ts
+++ b/frontend/src/community/common/utils/commonUtil.ts
@@ -614,7 +614,13 @@ export const replaceTabQueryParam = (path: string, tabId: string): void => {
   const [basePath, query] = path.split("?");
   const params = new URLSearchParams(query);
   params.set("tab", tabId);
-  globalThis.history.replaceState(null, "", `${basePath}?${params.toString()}`);
+  const newUrl = `${basePath}?${params.toString()}`;
+
+  globalThis.history.replaceState(
+    { ...globalThis.history.state, as: newUrl },
+    "",
+    newUrl
+  );
 };
 
 export const getPhoneNumberMaxLength = (countryCodeValue: string): number => {

--- a/frontend/src/community/common/utils/commonUtil.ts
+++ b/frontend/src/community/common/utils/commonUtil.ts
@@ -611,10 +611,38 @@ export const isAndroidDevice = (): boolean => {
 };
 
 export const replaceTabQueryParam = (path: string, tabId: string): void => {
-  const [basePath, query] = path.split("?");
-  const params = new URLSearchParams(query);
+  const [basePath] = path.split("?");
+  const params = new URLSearchParams();
   params.set("tab", tabId);
   const newUrl = `${basePath}?${params.toString()}`;
+
+  globalThis.history.replaceState(
+    { ...globalThis.history.state, as: newUrl },
+    "",
+    newUrl
+  );
+};
+
+export const updateUrlQueryParam = (
+  key: string,
+  value: string | null
+): void => {
+  if (typeof globalThis.window === "undefined") {
+    return;
+  }
+
+  const params = new URLSearchParams(globalThis.location.search);
+
+  if (value === null) {
+    params.delete(key);
+  } else {
+    params.set(key, value);
+  }
+
+  const queryString = params.toString();
+  const newUrl = queryString
+    ? `${globalThis.location.pathname}?${queryString}`
+    : globalThis.location.pathname;
 
   globalThis.history.replaceState(
     { ...globalThis.history.state, as: newUrl },

--- a/frontend/src/community/people/components/molecules/DirectorySteppers/DirectorySteppers.tsx
+++ b/frontend/src/community/people/components/molecules/DirectorySteppers/DirectorySteppers.tsx
@@ -117,6 +117,10 @@ const DirectorySteppers = ({
   ];
 
   const handleStepClick = (step: EditPeopleFormTypes) => {
+    if (step === currentStep) {
+      return;
+    }
+
     setNextStep(step);
 
     if (!hasChanged) {

--- a/frontend/src/community/people/components/molecules/DirectorySteppers/DirectorySteppers.tsx
+++ b/frontend/src/community/people/components/molecules/DirectorySteppers/DirectorySteppers.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { RefObject, useEffect, useState } from "react";
 
 import { useAuth } from "~community/auth/providers/AuthProvider";
@@ -9,7 +10,9 @@ import {
   EmployeeTypes,
   ManagerTypes
 } from "~community/common/types/AuthTypes";
+import { replaceTabQueryParam } from "~community/common/utils/commonUtil";
 import { useGetSupervisedByMe } from "~community/people/api/PeopleApi";
+import useFormChangeDetector from "~community/people/hooks/useFormChangeDetector";
 import { usePeopleStore } from "~community/people/store/store";
 import { EditPeopleFormTypes } from "~community/people/types/PeopleEditTypes";
 
@@ -32,9 +35,13 @@ const DirectorySteppers = ({
 
   const { user } = useAuth();
 
+  const router = useRouter();
+
   const { isSuperAdmin, isPeopleAdmin, userId } = useSessionData();
 
   const { setNextStep, currentStep } = usePeopleStore((state) => state);
+
+  const { hasChanged } = useFormChangeDetector();
 
   const [prevStep, setPrevStep] = useState<EditPeopleFormTypes | null>(null);
 
@@ -111,6 +118,10 @@ const DirectorySteppers = ({
 
   const handleStepClick = (step: EditPeopleFormTypes) => {
     setNextStep(step);
+
+    if (!hasChanged) {
+      replaceTabQueryParam(router.asPath, step.toLowerCase());
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { useGetEmployee } from "~community/people/api/PeopleApi";
 import { useGetAllTeams } from "~community/people/api/TeamApi";
 import { TeamNamesType } from "~community/people/types/TeamTypes";
+import useDefaultTabNavigation from "~community/people/hooks/useDefaultTabNavigation";
 import useFormChangeDetector from "~community/people/hooks/useFormChangeDetector";
 import { usePeopleStore } from "~community/people/store/store";
 import { EditPeopleFormTypes } from "~community/people/types/PeopleEditTypes";
@@ -40,6 +41,8 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
     setCurrentStep(EditPeopleFormTypes.personal);
     setNextStep(EditPeopleFormTypes.personal);
   }, []);
+
+  useDefaultTabNavigation();
 
   useEffect(() => {
     if (employeeData) {

--- a/frontend/src/community/people/hooks/useDefaultTabNavigation.tsx
+++ b/frontend/src/community/people/hooks/useDefaultTabNavigation.tsx
@@ -1,26 +1,28 @@
-import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { usePeopleStore } from "../store/store";
 import { EditPeopleFormTypes } from "../types/PeopleEditTypes";
 
 const useDefaultTabNavigation = () => {
-  const router = useRouter();
-  const { tab } = router.query;
-
-  const { nextStep, setNextStep } = usePeopleStore((state) => state);
+  const { setNextStep } = usePeopleStore((state) => state);
 
   useEffect(() => {
-    if (
-      tab === EditPeopleFormTypes.leave.toLowerCase() &&
-      nextStep !== EditPeopleFormTypes.leave
-    ) {
-      setNextStep(EditPeopleFormTypes.leave);
-    } else if (
-      tab === EditPeopleFormTypes.timesheet.toLowerCase() &&
-      nextStep !== EditPeopleFormTypes.timesheet
-    ) {
-      setNextStep(EditPeopleFormTypes.timesheet);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const tab = new URLSearchParams(window.location.search).get("tab");
+
+    if (!tab) {
+      return;
+    }
+
+    const matchedStep = Object.values(EditPeopleFormTypes).find(
+      (step) => step.toLowerCase() === tab.toLowerCase()
+    );
+
+    if (matchedStep) {
+      setNextStep(matchedStep);
     }
   }, []);
 };


### PR DESCRIPTION
### TaskId: (https://github.com/SkappHQ/skapp/issues/2857)

### Summary

The active profile tab (Personal / Documents / etc.) was tracked only in the people store, not the URL. Opening an eSign document navigates to the eSign module and Back uses `router.back()`, returning to the profile URL — but since the tab wasn't in the URL, the page remounted onto the default (Personal) tab instead of Documents.

**Root Cause:**
The selected profile tab lived only in Zustand store state and was reset to Personal by the profile wrappers' mount effect, so it was lost across the eSign round-trip.

**Corrective Actions:**
- Persist the active tab in the URL (`?tab=<step>`) on tab click via `replaceTabQueryParam`, updating history with `history.replaceState` — a shallow `router.replace` remounts the profile page and resets the tab.
- Preserve Next.js's existing history state when writing the param so browser back/forward keeps working (previously it passed `null`, which broke back/forward).
- Restore the tab on mount in `useDefaultTabNavigation`, reading it from `window.location.search` and re-asserting it unconditionally so the wrappers' force-to-Personal mount effect doesn't override it.
- Wire the restore into the account profile view (`AccountSectionWrapper`) as well.

**Verification:**
- Manually verified: switching tabs updates the URL on first click; opening an eSign document and pressing Back returns to the Documents tab; refreshing on `?tab=documents` opens Documents; browser back/forward work with the param present.

### How to test

1. Open an employee's profile → **Documents** tab.
2. Open the **eSigned Documents** folder and open a document (navigates to the eSign module).
3. Click **Back** — you should return to the **Documents** tab (not Personal).
4. Confirm the URL reflects the tab (`?tab=documents`) and that browser back/forward behave correctly with the param attached.