### PR TITLE
[Fix]: 1114 Fix job family legend overflow in dashboard

### DIFF
--- a/frontend/src/community/people/utils/eChartOptions/jobFamilyOverviewChartOptions.ts
+++ b/frontend/src/community/people/utils/eChartOptions/jobFamilyOverviewChartOptions.ts
@@ -36,13 +36,25 @@ export const useJobFamilyOverviewChartOptions = (
       right: "1%"
     },
     legend: {
+      type: "scroll",
       show: !(isLaptopScreen && !isTabScreen),
       orient: "vertical",
       right: 30,
-      top: "center",
+      top: "middle",
+      height: "90%",
       icon: "circle",
       itemWidth: 10,
       itemHeight: 10,
+      itemGap: 24,
+      pageButtonPosition: "end",
+      pageIconSize: 10,
+      pageIconColor: theme.palette.text.primary,
+      pageIconInactiveColor: theme.palette.grey[300],
+      pageTextStyle: {
+        color: theme.palette.text.primary,
+        fontSize: 14,
+        fontFamily: theme.typography.fontFamily
+      },
       textStyle: {
         color: theme.palette.text.primary,
         fontSize: 12,


### PR DESCRIPTION
## PR checklist

### TaskId: (https://rootcode.skapp.com/pm/projects/SKAPP/items/1114)

### Summary

**Root Cause:**
The Job family overview pie chart's ECharts legend was configured with `orient: "vertical"` but no `type`, so ECharts rendered every legend entry at once. With many job families the legend column grew taller than the chart area, overlapping and squashing the pie so the UI appeared broken.

**Contributing Factors:**
The legend had no height bound and no pagination, so nothing constrained how many items were laid out — the failure only surfaced once the number of job families exceeded what fit in the fixed chart height.

**Corrective Actions / Action Items:**
- Switched the legend to `type: "scroll"` so entries paginate instead of all rendering at once.
- Bounded the legend with `height: "90%"` and `top: "middle"` so ECharts knows how many items fit per page and centers the block.
- Added page controls: `pageButtonPosition: "end"`, `pageIconSize`, `pageIconColor`/`pageIconInactiveColor`, and themed `pageTextStyle` (the up/down arrows and `1/n` page indicator).
- Tuned `itemGap` for readable row spacing.

**Verification of Effectiveness:**
Verified on the People dashboard that the pie chart keeps its full size and the legend paginates with up/down arrows and a page counter regardless of the number of job families. Existing chart-options unit test still passes.

### How to test

1. Open the People dashboard with an org that has many job families (enough to overflow the legend).
2. Confirm the pie chart renders at full size and the legend shows paginated entries with up/down arrows and a `1/n` indicator, instead of overflowing and squashing the chart.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
