### PR TITLE
add loader to decline button

### DIFF
--- a/frontend/src/community/common/assets/languages/english/leaveModule.json
+++ b/frontend/src/community/common/assets/languages/english/leaveModule.json
@@ -831,6 +831,8 @@
       "reasonData": "{{reason}}",
       "approveAreaLabel": "Pressing enter on this button will approve the leave request.",
       "cancelAreaLabel": "Pressing enter on this button will open the decline lave modal. In that modal you can decline the leave request",
+      "declineAreaLabel": "Pressing enter on this button will decline the leave request.",
+      "cancelDeclineAreaLabel": "Pressing enter on this button will close the decline leave modal without declining the leave request.",
       "memberHeader": "MEMBER",
       "leavePeriodHeader": "LEAVE PERIOD",
       "leaveTypeHeader": "TYPE",

--- a/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
@@ -100,6 +100,7 @@ const ManagerDeclineLeaveModal = ({
           variant={"tertiary"}
           onClick={closeModel}
           disabled={isPending}
+          aria-label={translateText(["cancelDeclineAreaLabel"])}
           icon={<CloseIcon />}
           iconPosition="end"
         >
@@ -109,6 +110,8 @@ const ManagerDeclineLeaveModal = ({
           variant={"error"}
           onClick={handelDecline}
           isLoading={isPending}
+          aria-busy={isPending}
+          aria-label={translateText(["declineAreaLabel"])}
           icon={<CloseIcon fill="var(--color-primary-text)" />}
           iconPosition="end"
         >

--- a/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
@@ -36,11 +36,18 @@ const ManagerDeclineLeaveModal = ({
   const [reason, setReason] = useState<string>("");
   const [error, setError] = useState<boolean>(false);
 
-  const { mutate, isSuccess, error: leaveCancelError } = useHandelLeaves();
+  const {
+    mutate,
+    isPending,
+    isSuccess,
+    error: leaveCancelError
+  } = useHandelLeaves();
 
   const { sendEvent } = useGoogleAnalyticsEvent();
 
   const handelDecline = (): void => {
+    if (isPending) return;
+
     if (validateDescription(reason)) setError(true);
     else {
       setError(false);
@@ -92,6 +99,7 @@ const ManagerDeclineLeaveModal = ({
         <ButtonV2
           variant={"tertiary"}
           onClick={closeModel}
+          disabled={isPending}
           icon={<CloseIcon />}
           iconPosition="end"
         >
@@ -100,6 +108,7 @@ const ManagerDeclineLeaveModal = ({
         <ButtonV2
           variant={"error"}
           onClick={handelDecline}
+          isLoading={isPending}
           icon={<CloseIcon fill="var(--color-primary-text)" />}
           iconPosition="end"
         >

--- a/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
@@ -48,13 +48,15 @@ const ManagerDeclineLeaveModal = ({
   const handelDecline = (): void => {
     if (isPending) return;
 
-    if (validateDescription(reason)) setError(true);
+    const trimmedReason = reason.trim();
+
+    if (validateDescription(trimmedReason)) setError(true);
     else {
       setError(false);
       const data = {
         leaveRequestId: leaveRequestData.leaveId as number,
         status: LeaveStatusTypes.DENIED.toUpperCase(),
-        reviewerComment: reason
+        reviewerComment: trimmedReason
       };
       mutate(data);
     }

--- a/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
+++ b/frontend/src/community/leave/components/molecules/ManagerLeaveModalContents/ManagerDeclineLeaveModal/ManagerDeclineLeaveModal.tsx
@@ -43,10 +43,12 @@ const ManagerDeclineLeaveModal = ({
     error: leaveCancelError
   } = useHandelLeaves();
 
+  const isSubmitting = isPending || isSuccess;
+
   const { sendEvent } = useGoogleAnalyticsEvent();
 
   const handelDecline = (): void => {
-    if (isPending) return;
+    if (isSubmitting) return;
 
     const trimmedReason = reason.trim();
 
@@ -101,7 +103,7 @@ const ManagerDeclineLeaveModal = ({
         <ButtonV2
           variant={"tertiary"}
           onClick={closeModel}
-          disabled={isPending}
+          disabled={isSubmitting}
           aria-label={translateText(["cancelDeclineAreaLabel"])}
           icon={<CloseIcon />}
           iconPosition="end"
@@ -111,8 +113,8 @@ const ManagerDeclineLeaveModal = ({
         <ButtonV2
           variant={"error"}
           onClick={handelDecline}
-          isLoading={isPending}
-          aria-busy={isPending}
+          isLoading={isSubmitting}
+          aria-busy={isSubmitting}
           aria-label={translateText(["declineAreaLabel"])}
           icon={<CloseIcon fill="var(--color-primary-text)" />}
           iconPosition="end"


### PR DESCRIPTION
## PR checklist

### TaskId: (https://rootcode.skapp.com/pm/projects/SKAPP/items/2931) 

### Summary
Disable the Decline button and show its loading spinner while the decline request is in flight, in `ManagerDeclineLeaveModal`.
- A leave decline that is submitted twice sends two `PATCH /leave/managers/{id}` calls. The first succeeds and moves the request to `DENIED`; the second hits the terminal-status guard in `LeaveServiceImpl.updateLeaveRequestByManager` and returns `LEAVE_ERROR_INVALID_LEAVE_REQUEST_STATUS_MANAGER`. Because the modal reports a mutation error in preference to success, the reviewer sees "decline failed" for a leave request that was in fact declined, and every retry reproduces the same error.
- Nothing on screen previously indicated a request was in progress: the button had no `isLoading`, no `disabled` and no spinner, so a second click was easy to make. Reviewers who hit the mandatory-message validation error first spent longer in the modal and hit this more often, which is why the ticket reads as "declining only works if you type the message before the first click".
- Fix follows the existing pattern: `isLoading={isPending}` on the primary action (same as `PolicyLeaveDeclineModal` and `ClockOutModal`), plus `disabled={isPending}` on Cancel (same as the shared `ConfirmationModal`). `ButtonV2` already resolves `disabled={rest?.disabled || isLoading}` internally, so one prop both disables the button and swaps in the `Spinner`.
-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
