### PR TITLE
[Fix] Tenant header missing in MCP connector sign-in flow

### DIFF
--- a/frontend/src/community/auth/utils/authUtils.ts
+++ b/frontend/src/community/auth/utils/authUtils.ts
@@ -23,6 +23,7 @@ import {
 } from "~enterprise/auth/utils/authUtils";
 import { authenticationEndpoints } from "~enterprise/common/api/utils/ApiEndpoints";
 import { TenantStatusEnums, TierEnum } from "~enterprise/common/enums/Common";
+import { isAuthHost } from "~enterprise/common/utils/tenantUtil";
 
 import { config } from "../../../../middleware";
 import { drawerHiddenProtectedRoutes } from "../constants/routeConfigs";
@@ -460,6 +461,27 @@ export const checkUserAuthentication = async (
   return userData;
 };
 
+const buildSignInUrl = (path: string, callback: string): string => {
+  const params = new URLSearchParams({ callback });
+
+  return `${path}?${params.toString()}`;
+};
+
+const resolveSignInUrl = (): string => {
+  const callback = new URLSearchParams(window.location.search).get("callback");
+
+  if (isAuthHost()) {
+    return callback
+      ? buildSignInUrl(ROUTES.AUTH.OAUTH_SIGNIN, callback)
+      : ROUTES.AUTH.OAUTH_SIGNIN;
+  }
+
+  return buildSignInUrl(
+    ROUTES.AUTH.SIGNIN,
+    callback || window.location.pathname
+  );
+};
+
 export const signOut = async (
   authTokenStore: AuthTokenSliceType,
   redirect: boolean = true
@@ -476,13 +498,7 @@ export const signOut = async (
     if (redirect === false || !hadActiveSession) return;
 
     if (typeof window !== "undefined") {
-      const urlParams = new URLSearchParams(window.location.search);
-      const existingCallback = urlParams.get("callback");
-
-      const callbackPath = existingCallback || window.location.pathname;
-      window.location.href = `${ROUTES.AUTH.SIGNIN}?callback=${encodeURIComponent(
-        callbackPath
-      )}`;
+      window.location.href = resolveSignInUrl();
     }
   } finally {
     isSigningOut = false;


### PR DESCRIPTION
## Summary

The MCP connector sign-in flow on `auth.skapp.dev` dead-ends on a backend 404 —
`{"message":"Tenant header missing in request","messageKey":"COMMON_ERROR_MODULE_EXCEPTION","code":404}`.
On that host only `/auth/*` is served by the frontend and every other path goes to the
backend, but `signOut()` still redirected to `/signin`, so a sign-in that lost its
session landed on Spring and the authorization request was lost.

## Changes in this repo (`SkappHQ/skapp`)

- `signOut()` resolves its redirect target by host — `ROUTES.AUTH.OAUTH_SIGNIN`
  (`/auth/signin`) on the auth host, `ROUTES.AUTH.SIGNIN` (`/signin`) everywhere else.
- The OAuth `callback` param is carried through unchanged, so the pending
  `/oauth2/authorize` request survives the round trip and the connector flow can resume.
- The redirect target is built by two small named helpers rather than inline in
  `signOut()`; the query value is encoded via `URLSearchParams` instead of a hand-rolled
  template.

`ROUTES.AUTH.OAUTH_SIGNIN` already existed — this is the first caller to use it on the
sign-out path.

## Feature scope (all repos)

Branch `fix/mcp-qa-bugs`. Only the super repo has changes.

| Repo | What changed |
|------|--------------|
| `SkappHQ/skapp` (super) | Host-aware sign-in redirect target in `signOut()` |
| `rootcodelabs/skapp-ep-*` | no changes |
| `rootcodelabs/skapp-pm` | no changes |
| `rootcodelabs/skapp-ai` | no changes |
| `rootcodelabs/skapp-migrations` | no changes |

## Architecture / flow

```mermaid
flowchart TD
    subgraph host["auth.skapp.dev"]
        R{"path"}
        R -->|"/auth/*"| FE["Next frontend"]
        R -->|"everything else"| BE["Spring backend"]
    end

    BE --> TF["TenantFilter: no X-Tenant-ID"]
    TF --> E404["404 Tenant header missing in request"]

    OLD["signOut -> /signin"] -.->|before| R
    NEW["signOut -> /auth/signin"] ==>|after| R

    style E404 fill:#ffdddd,stroke:#cc0000
    style FE fill:#ddffdd,stroke:#00aa00
```

```mermaid
sequenceDiagram
    autonumber
    actor U as Browser
    participant A as auth.skapp.dev
    participant F as Next frontend
    participant B as Spring backend

    U->>A: GET /oauth2/authorize
    A->>B: (backend)
    B-->>U: 302 /auth/signin?callback=<authorize url>
    U->>F: GET /auth/signin

    rect rgb(255, 235, 235)
        Note over U,B: Before — the sign-out redirect left the frontend
        F-->>U: 302 /signin?callback=<authorize url>
        U->>B: GET /signin
        B-->>U: 404 Tenant header missing in request
        Note over U: flow dead-ends, authorization lost
    end

    rect rgb(235, 255, 235)
        Note over U,F: After — it stays on the auth host's own route
        F-->>U: 302 /auth/signin?callback=<authorize url>
        U->>F: GET /auth/signin
        U->>A: GET /oauth2/authorize (resumed)
        A-->>U: 302 consent -> claude.ai callback
    end
```

## Exclusions — deliberately NOT in this PR

- **Internal Next API routes on the auth host.** `/api/auth/access-token` and
  `/api/clear-cookies` are also served by the backend on that host and return the same
  404, which makes `persistSession()` return `false` and fails credential sign-in.
  That is being addressed at the load balancer (an `/api/*` rule pointing at the
  frontend target on `auth.skapp.dev`) rather than in application code, so no rewrite
  or path-resolution helper is included here.
- **Refresh-token handling.** Skipping the refresh when no tenant resolves, treating a
  400 `COMMON_ERROR_INVALID_REFRESH_TOKEN` as a rejected session, and clearing the stale
  `accessToken` cookie. Scoped out to keep this PR to the reported defect.
- **MCP connector tier restriction.** Separate QA ticket, separate PR.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Gitlink updates are
  done at **deployment time**, not in feature PRs.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit tests | partial | The only spec touching the changed code (`redirectionHandler.test.ts`) fails to run on `develop` too — `Cannot find module 'next-auth/react'`. Verified pre-existing by re-running against a stashed tree. |
| Formatter (BE only) | n/a | Frontend-only change. Prettier run on the touched file: clean. |
| tsc + lint (BE only) | n/a | Frontend-only change. Ran anyway: `tsc` byte-identical to the `develop` baseline (663 pre-existing errors before and after); eslint clean. |
| Build | yes | `next build` exit 0. |
| e2e (Playwright) | no | The local stack was not running, and the local nginx routes `/` to the frontend on `auth.akila.site`, so it does not mirror the deployed auth host and cannot reproduce this defect. Verified against the deployed dev environment with read-only probes instead (below). |

### Verification against dev

```
GET https://auth.skapp.dev/signin           404 application/json   (backend, "Tenant header missing in request")
GET https://auth.skapp.dev/auth/signin      200 text/html          (frontend)
GET https://auth.skapp.dev/oauth2/authorize 302 -> https://auth.skapp.dev/auth/signin?callback=...
```

The backend already emits `/auth/signin`, so `signOut()` was the only remaining caller
sending the browser to `/signin` on that host — which is exactly the URL in the QA
screenshot, `callback` and all.
