### PR TITLE
[Fix] MCP connector OAuth 2.1 authorization and token lifecycle

### DIFF
--- a/frontend/src/community/auth/utils/authUtils.ts
+++ b/frontend/src/community/auth/utils/authUtils.ts
@@ -23,6 +23,7 @@ import {
 } from "~enterprise/auth/utils/authUtils";
 import { authenticationEndpoints } from "~enterprise/common/api/utils/ApiEndpoints";
 import { TenantStatusEnums, TierEnum } from "~enterprise/common/enums/Common";
+import { isAuthHost } from "~enterprise/common/utils/tenantUtil";
 
 import { config } from "../../../../middleware";
 import { drawerHiddenProtectedRoutes } from "../constants/routeConfigs";
@@ -460,6 +461,27 @@ export const checkUserAuthentication = async (
   return userData;
 };
 
+const buildSignInUrl = (path: string, callback: string): string => {
+  const params = new URLSearchParams({ callback });
+
+  return `${path}?${params.toString()}`;
+};
+
+const resolveSignInUrl = (): string => {
+  const callback = new URLSearchParams(window.location.search).get("callback");
+
+  if (isAuthHost()) {
+    return callback
+      ? buildSignInUrl(ROUTES.AUTH.OAUTH_SIGNIN, callback)
+      : ROUTES.AUTH.OAUTH_SIGNIN;
+  }
+
+  return buildSignInUrl(
+    ROUTES.AUTH.SIGNIN,
+    callback || window.location.pathname
+  );
+};
+
 export const signOut = async (
   authTokenStore: AuthTokenSliceType,
   redirect: boolean = true
@@ -476,13 +498,7 @@ export const signOut = async (
     if (redirect === false || !hadActiveSession) return;
 
     if (typeof window !== "undefined") {
-      const urlParams = new URLSearchParams(window.location.search);
-      const existingCallback = urlParams.get("callback");
-
-      const callbackPath = existingCallback || window.location.pathname;
-      window.location.href = `${ROUTES.AUTH.SIGNIN}?callback=${encodeURIComponent(
-        callbackPath
-      )}`;
+      window.location.href = resolveSignInUrl();
     }
   } finally {
     isSigningOut = false;

--- a/frontend/src/community/common/utils/axiosInterceptor.ts
+++ b/frontend/src/community/common/utils/axiosInterceptor.ts
@@ -15,11 +15,6 @@ export const authFetchV2 = axios.create({
   baseURL: getApiUrl() + ApiVersions.V2
 });
 
-export const authFetchSameOrigin = axios.create({
-  baseURL: "",
-  withCredentials: true
-});
-
 const requestInterceptorConfig = async (config: InternalAxiosRequestConfig) => {
   const accessToken = await getAccessToken(useCommonStore.getState());
 
@@ -50,11 +45,6 @@ authFetch.interceptors.request.use(
 );
 
 authFetchV2.interceptors.request.use(
-  requestInterceptorConfig,
-  requestInterceptorConfigError
-);
-
-authFetchSameOrigin.interceptors.request.use(
   requestInterceptorConfig,
   requestInterceptorConfigError
 );


### PR DESCRIPTION
## Changes in this repository

- `axiosInterceptor.ts` — removes `authFetchSameOrigin`, added for the OAuth feature
  and left with no consumers once the module took over its own clients.

## Summary

The MCP connector could not complete an OAuth 2.1 authorization against the dev
authorization host, and could never refresh a token it did obtain.

On `auth.skapp.dev` the ALB serves the frontend only under `/auth/*`; every other
path is the backend. The connector screens ran on the shared tenant-app session
layer, whose Next API routes (`/api/auth/access-token`, `/api/clear-cookies`)
therefore answer with the backend's `Tenant header missing` 404. Sign-in reported
failure after authenticating, and the consent screen bounced back to sign-in in a
loop.

Behind that sat three authorization-server defects, each hidden by the one before:
the consent endpoints demanded a tenant-app JWT they can never hold on the auth
host; public clients could not authenticate on the refresh grant, so every issued
refresh token was unusable; and persisted authorizations could not be deserialised,
which failed refresh even once the client authenticated.

Password recovery and the account switch are also removed from the connector
screens, so the flow offers no way out of itself.

## Flow

```mermaid
sequenceDiagram
    participant C as MCP connector
    participant AS as Authorization server
    participant FE as auth host /auth/*
    participant API as api host

    C->>AS: GET /oauth2/authorize (PKCE S256)
    AS-->>C: redirect to /auth/signin?callback=...
    C->>FE: sign-in screen
    FE->>API: POST /v1/auth/session/sign-in (X-Tenant-ID)
    API-->>FE: access token
    FE->>AS: POST /v1/auth/oauth/session-login (token + tenant)
    AS-->>FE: authorization session established
    FE->>AS: resume /oauth2/authorize
    AS-->>FE: redirect to /auth/oauth-consent
    FE->>AS: GET /v1/auth/oauth/consent (session authenticated)
    FE->>AS: POST /v1/auth/oauth/consent (approve)
    AS-->>C: redirect_uri?code=...&state=...
    C->>AS: POST /oauth2/token (code + verifier)
    AS-->>C: access token + refresh token
    C->>AS: POST /oauth2/token (refresh, client_id only)
    AS-->>C: rotated access + refresh token
```

## Testing

Playwright e2e against a local stack (backend, frontend, nginx mirroring the dev
host split) — **16/16 passing**:

| Area | Covered |
|---|---|
| Discovery | issuer, endpoints, PKCE `S256` only, no implicit/password grant, `none` client auth, OAuth vs OIDC agreement |
| Authorization | domain lookup, credential sign-in, consent, approve to `code`, cancel to `error=access_denied` |
| Token | code exchange, `userinfo`, single-use code, wrong verifier refused, missing verifier refused |
| Refresh | new token for same user/tenant/scope, rotation chain continues, consumed links dead, unknown token and wrong client refused without consuming the real one |
| SSO | provider handoff, provider return resumes to consent, denial returns to sign-in |
| Regression | flow completes with every `/api/*` route 404'd; no untranslated keys; tampered request refused; a pending authorization is readable only by its owning session |

Backend `mvn test` passes. Note its integration suites execute 0 tests in this
environment, so the e2e run above is the real evidence.

## Exclusions

- Discovery advertises `client_credentials` and token-exchange while the client
  policy permits only `authorization_code` and `refresh_token`. Pre-existing;
  changing advertised grants belongs in its own change.
- `pages/enterprise/signin.tsx` reads three aria keys from the community
  `onboardingAria` bundle that do not exist there, so they render as key paths.
  Pre-existing and outside the connector flow.
- The local nginx mirror serves `/api/*` from the frontend on the auth host where
  the ALB serves it from the backend, so it does not reproduce this bug. The
  isolation spec simulates the deployed split instead.

## Ignored

Submodule pointer bumps are not committed; they are applied at deployment.
