### PR TITLE
Remove board column from deal order index baseline schema

### DIFF
--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-tables.sql
@@ -694,7 +694,6 @@ CREATE TABLE IF NOT EXISTS `crm_deal`
 CREATE TABLE IF NOT EXISTS `crm_deal_order_index`
 (
     `deal_id` bigint                                         NOT NULL,
-    `board`   text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
     `list`    text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
     PRIMARY KEY (`deal_id`),
     CONSTRAINT `FK_crm_deal_order_index_crm_deal_deal_id` FOREIGN KEY (`deal_id`) REFERENCES `crm_deal` (`id`)


### PR DESCRIPTION
### What
Removes the unused `board` column from the `crm_deal_order_index` table in the community baseline schema.

### Why
The column was only ever written, never read — board ordering lives on `crm_deal.order_index`, which stays its source of truth. The table now carries only the list-view key.

Without this, a fresh community install creates `board` as `NOT NULL`; once the entity stops mapping it, Hibernate omits it on insert and deal creation fails.

### Notes
- Edited in place rather than via an alter script: the table was added to this same changeset recently and is unreleased, so an alter script would fail on fresh installs where the column never existed.
- Safe to merge on its own — `CrmDealOrderIndex` is currently referenced by nothing on `develop` (no DAO, no service), so the mapping is inert until the feature branch lands.

### Related
- SkappHQ/skapp#1850 — removes the `board` field from the entity and the code that populated it
- rootcodelabs/skapp-migrations#219 — drops the column from existing tenant databases
