### PR TITLE
[Fix] Rank work location search results by match relevance

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
@@ -72,8 +72,8 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 
 		String searchKeyword = workLocationFilterDto.getSearchKeyword();
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String likePattern = "%" + escapedLowerKeyword(searchKeyword) + "%";
-			predicates.add(cb.like(cb.lower(workLocation.get(WorkLocation_.name)), likePattern, '\\'));
+			String escaped = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
+			predicates.add(cb.like(cb.lower(workLocation.get(WorkLocation_.name)), "%" + escaped + "%", '\\'));
 		}
 
 		return predicates;
@@ -84,11 +84,12 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String normalizedKeyword = searchKeyword.toLowerCase();
+			String escaped = StringUtils.escapeLikePattern(normalizedKeyword);
 			Expression<String> lowerName = cb.lower(workLocation.get(WorkLocation_.name));
 
 			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
 				.when(cb.equal(lowerName, normalizedKeyword), 0)
-				.when(cb.like(lowerName, escapedLowerKeyword(searchKeyword) + "%", '\\'), 1)
+				.when(cb.like(lowerName, escaped + "%", '\\'), 1)
 				.otherwise(2);
 
 			orders.add(cb.asc(relevanceRank));
@@ -97,10 +98,6 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		orders.add(cb.asc(cb.lower(workLocation.get(WorkLocation_.name))));
 
 		return orders;
-	}
-
-	private String escapedLowerKeyword(String searchKeyword) {
-		return StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
 	}
 
 	private Long getTotalCount(CriteriaBuilder cb, WorkLocationFilterDto workLocationFilterDto) {

--- a/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
@@ -4,10 +4,13 @@ import com.skapp.community.common.model.WorkLocation;
 import com.skapp.community.common.model.WorkLocation_;
 import com.skapp.community.common.payload.request.WorkLocationFilterDto;
 import com.skapp.community.common.repository.WorkLocationRepository;
+import com.skapp.community.common.util.StringUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +38,7 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		List<Predicate> predicates = buildPredicates(cb, workLocation, workLocationFilterDto);
 		query.where(predicates.toArray(new Predicate[0]));
 
-		query.orderBy(cb.asc(cb.lower(workLocation.get(WorkLocation_.name))));
+		query.orderBy(buildOrderBy(cb, workLocation, workLocationFilterDto.getSearchKeyword()));
 
 		TypedQuery<WorkLocation> typedQuery = entityManager.createQuery(query);
 		if (pageable.isPaged()) {
@@ -69,11 +72,35 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 
 		String searchKeyword = workLocationFilterDto.getSearchKeyword();
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String likePattern = "%" + searchKeyword.toLowerCase() + "%";
-			predicates.add(cb.like(cb.lower(workLocation.get(WorkLocation_.name)), likePattern));
+			String likePattern = "%" + escapedLowerKeyword(searchKeyword) + "%";
+			predicates.add(cb.like(cb.lower(workLocation.get(WorkLocation_.name)), likePattern, '\\'));
 		}
 
 		return predicates;
+	}
+
+	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<WorkLocation> workLocation, String searchKeyword) {
+		List<Order> orders = new ArrayList<>();
+
+		if (searchKeyword != null && !searchKeyword.isBlank()) {
+			String normalizedKeyword = searchKeyword.toLowerCase();
+			Expression<String> lowerName = cb.lower(workLocation.get(WorkLocation_.name));
+
+			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
+				.when(cb.equal(lowerName, normalizedKeyword), 0)
+				.when(cb.like(lowerName, escapedLowerKeyword(searchKeyword) + "%", '\\'), 1)
+				.otherwise(2);
+
+			orders.add(cb.asc(relevanceRank));
+		}
+
+		orders.add(cb.asc(cb.lower(workLocation.get(WorkLocation_.name))));
+
+		return orders;
+	}
+
+	private String escapedLowerKeyword(String searchKeyword) {
+		return StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
 	}
 
 	private Long getTotalCount(CriteriaBuilder cb, WorkLocationFilterDto workLocationFilterDto) {

--- a/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
@@ -88,13 +88,6 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		return predicates;
 	}
 
-	/**
-	 * Orders matches by relevance when a search keyword is supplied: an exact name match
-	 * first, then names starting with the keyword, then names merely containing it. Names
-	 * are ordered alphabetically within each rank, and alphabetically throughout when no
-	 * keyword is supplied.
-	 * @param searchKeyword the trimmed, lower-cased keyword, or null when absent
-	 */
 	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<WorkLocation> workLocation, String searchKeyword) {
 		List<Order> orders = new ArrayList<>();
 

--- a/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/repository/impl/WorkLocationRepositoryImpl.java
@@ -21,10 +21,17 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Repository
 @RequiredArgsConstructor
 public class WorkLocationRepositoryImpl implements WorkLocationRepository {
+
+	private static final int EXACT_MATCH_RANK = 0;
+
+	private static final int PREFIX_MATCH_RANK = 1;
+
+	private static final int PARTIAL_MATCH_RANK = 2;
 
 	private final EntityManager entityManager;
 
@@ -35,10 +42,14 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		CriteriaQuery<WorkLocation> query = cb.createQuery(WorkLocation.class);
 		Root<WorkLocation> workLocation = query.from(WorkLocation.class);
 
-		List<Predicate> predicates = buildPredicates(cb, workLocation, workLocationFilterDto);
+		String rawSearchKeyword = workLocationFilterDto.getSearchKeyword();
+		String searchKeyword = rawSearchKeyword == null || rawSearchKeyword.isBlank() ? null
+				: rawSearchKeyword.trim().toLowerCase(Locale.ROOT);
+
+		List<Predicate> predicates = buildPredicates(cb, workLocation, searchKeyword);
 		query.where(predicates.toArray(new Predicate[0]));
 
-		query.orderBy(buildOrderBy(cb, workLocation, workLocationFilterDto.getSearchKeyword()));
+		query.orderBy(buildOrderBy(cb, workLocation, searchKeyword));
 
 		TypedQuery<WorkLocation> typedQuery = entityManager.createQuery(query);
 		if (pageable.isPaged()) {
@@ -47,7 +58,7 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		}
 		List<WorkLocation> results = typedQuery.getResultList();
 
-		Long total = getTotalCount(cb, workLocationFilterDto);
+		Long total = getTotalCount(cb, searchKeyword);
 		return new PageImpl<>(results, pageable, total);
 	}
 
@@ -64,33 +75,37 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		return entityManager.createQuery(query).getResultList();
 	}
 
-	private List<Predicate> buildPredicates(CriteriaBuilder cb, Root<WorkLocation> workLocation,
-			WorkLocationFilterDto workLocationFilterDto) {
+	private List<Predicate> buildPredicates(CriteriaBuilder cb, Root<WorkLocation> workLocation, String searchKeyword) {
 		List<Predicate> predicates = new ArrayList<>();
 
 		predicates.add(cb.isFalse(workLocation.get(WorkLocation_.isDeleted)));
 
-		String searchKeyword = workLocationFilterDto.getSearchKeyword();
-		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String escaped = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
+		if (searchKeyword != null) {
+			String escaped = StringUtils.escapeLikePattern(searchKeyword);
 			predicates.add(cb.like(cb.lower(workLocation.get(WorkLocation_.name)), "%" + escaped + "%", '\\'));
 		}
 
 		return predicates;
 	}
 
+	/**
+	 * Orders matches by relevance when a search keyword is supplied: an exact name match
+	 * first, then names starting with the keyword, then names merely containing it. Names
+	 * are ordered alphabetically within each rank, and alphabetically throughout when no
+	 * keyword is supplied.
+	 * @param searchKeyword the trimmed, lower-cased keyword, or null when absent
+	 */
 	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<WorkLocation> workLocation, String searchKeyword) {
 		List<Order> orders = new ArrayList<>();
 
-		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String normalizedKeyword = searchKeyword.toLowerCase();
-			String escaped = StringUtils.escapeLikePattern(normalizedKeyword);
+		if (searchKeyword != null) {
+			String escaped = StringUtils.escapeLikePattern(searchKeyword);
 			Expression<String> lowerName = cb.lower(workLocation.get(WorkLocation_.name));
 
 			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
-				.when(cb.equal(lowerName, normalizedKeyword), 0)
-				.when(cb.like(lowerName, escaped + "%", '\\'), 1)
-				.otherwise(2);
+				.when(cb.equal(lowerName, searchKeyword), EXACT_MATCH_RANK)
+				.when(cb.like(lowerName, escaped + "%", '\\'), PREFIX_MATCH_RANK)
+				.otherwise(PARTIAL_MATCH_RANK);
 
 			orders.add(cb.asc(relevanceRank));
 		}
@@ -100,12 +115,12 @@ public class WorkLocationRepositoryImpl implements WorkLocationRepository {
 		return orders;
 	}
 
-	private Long getTotalCount(CriteriaBuilder cb, WorkLocationFilterDto workLocationFilterDto) {
+	private Long getTotalCount(CriteriaBuilder cb, String searchKeyword) {
 		CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
 		Root<WorkLocation> countRoot = countQuery.from(WorkLocation.class);
 		countQuery.select(cb.count(countRoot));
 
-		List<Predicate> predicates = buildPredicates(cb, countRoot, workLocationFilterDto);
+		List<Predicate> predicates = buildPredicates(cb, countRoot, searchKeyword);
 		countQuery.where(predicates.toArray(new Predicate[0]));
 
 		return entityManager.createQuery(countQuery).getSingleResult();


### PR DESCRIPTION
## Summary

Work location search returned results in plain alphabetical order, so a location that matched the search term exactly could be pushed below weaker matches. Searching `Zurichtown` with `Greater Zurichtown Campus`, `Zurichtown Annex` and `Zurichtown` in the list put the exact match **last**. This ranks results by match relevance first, keeping alphabetical order only as the tie-breaker within a relevance tier.

## Changes in this repo

- `WorkLocationRepositoryImpl.findWorkLocations` no longer applies an unconditional `ORDER BY lower(name) ASC`. Ordering is now built by a new `buildOrderBy(...)`:
  - **with** a search keyword — a relevance rank (`0` exact match, `1` prefix match, `2` contains match) is the primary sort, with `lower(name)` as the within-tier tie-breaker;
  - **without** a keyword — unchanged, plain alphabetical.
- LIKE wildcards in the search keyword are escaped via the existing `StringUtils.escapeLikePattern`, so a keyword containing `%` or `_` matches literally instead of acting as a wildcard. Both the filter predicate and the new prefix-match rank use the same escaped pattern, so filtering and ranking cannot drift apart.

Ordering stays deterministic (`rank`, then `lower(name)`), so paging and the infinite-scroll list on the Work Locations screen remain stable across pages.

This mirrors the ranking convention already used by `CrmCompanyRepositoryImpl.buildOrderBy`, and the inline `'\\'` LIKE escape character matches `LeavePolicyRepositoryImpl` and every other call site in the codebase.
