### PR TITLE
fix: enhance CRM task filtering by owner to include tasks linked through deals

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmTaskRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmTaskRepositoryImpl.java
@@ -356,11 +356,11 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 			predicates.add(cb.equal(root.get(CrmTask_.owner).get(Employee_.employeeId), params.getOwnerId()));
 		}
 
+		Join<CrmTask, CrmContact> contactJoin = root.join(CrmTask_.contact, JoinType.LEFT);
+		Join<CrmTask, CrmDeal> dealJoin = root.join(CrmTask_.deal, JoinType.LEFT);
+
 		if (params.getSearchKeyword() != null && !params.getSearchKeyword().isBlank()) {
 			String escaped = StringUtils.escapeLikePattern(params.getSearchKeyword().trim().toLowerCase());
-
-			Join<CrmTask, CrmContact> contactJoin = root.join(CrmTask_.contact, JoinType.LEFT);
-			Join<CrmTask, CrmDeal> dealJoin = root.join(CrmTask_.deal, JoinType.LEFT);
 
 			predicates.add(cb.or(cb.like(cb.lower(root.get(CrmTask_.name)), "%" + escaped + "%"),
 					cb.like(cb.lower(contactJoin.get(CrmContact_.name)), "%" + escaped + "%"),
@@ -368,7 +368,10 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		}
 
 		if (params.getContactId() != null) {
-			predicates.add(cb.equal(root.get(CrmTask_.contact).get(CrmContact_.id), params.getContactId()));
+			Join<CrmDeal, CrmContact> dealContactJoin = dealJoin.join(CrmDeal_.contact, JoinType.LEFT);
+
+			predicates.add(cb.or(cb.equal(contactJoin.get(CrmContact_.id), params.getContactId()),
+					cb.equal(dealContactJoin.get(CrmContact_.id), params.getContactId())));
 		}
 
 		if (params.getDealId() != null) {

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v2/CrmTaskControllerV2IntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v2/CrmTaskControllerV2IntegrationTest.java
@@ -417,6 +417,36 @@ class CrmTaskControllerV2IntegrationTest {
 	}
 
 	@Test
+	@DisplayName("Get tasks filtered by contactId - Includes tasks linked only through the contact's deal")
+	void getTasks_ByContactId_IncludesDealLinkedTasks() throws Exception {
+		savedTask("Directly Linked Task", false);
+		savedTaskWith("Deal Linked Task", company, null, savedDeal("Contact Deal"), false);
+
+		performGetByContactRequest(contactId).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['items'].length()").value(2))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(2));
+	}
+
+	@Test
+	@DisplayName("Get tasks filtered by contactId - Excludes tasks on another contact's deal")
+	void getTasks_ByContactId_ExcludesOtherContactsDealTasks() throws Exception {
+		savedTask("Directly Linked Task", false);
+
+		CrmDeal otherDeal = savedDeal("Other Contact Deal");
+		otherDeal.setContact(savedContact("Other Deal Contact"));
+		crmDealDao.save(otherDeal);
+		savedTaskWith("Other Deal Task", company, null, otherDeal, false);
+
+		performGetByContactRequest(contactId).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['items'].length()").value(1))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(1));
+	}
+
+	@Test
 	@DisplayName("Get tasks with size -1 - Returns every match in a single page")
 	void getTasks_UnpagedSize_ReturnsEveryMatchInOnePage() throws Exception {
 		for (int index = 0; index < 12; index++) {


### PR DESCRIPTION
…ugh deals

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

The contactId filter on GET /v2/crm/task matched only a task's own contact column, so a task linked to a contact through its deal was left out.

That gap matters now because of the CRM v2 refactor. The Contact side panel's Tasks tab currently reads contact.tasks off the v1 contact-detail response, which is not owner-scoped — a Sales Representative sees every rep's tasks on that contact. [#1880](https://github.com/SkappHQ/skapp/issues/1880) fixes that by moving the panel onto GET /v2/crm/task?contactId=…, which is owner-scoped. But the v1 query it replaces (findByContactIdWithAssociations) matched task.contact OR task.deal.contact, and the v2 filter did not. Without this change, [#1880](https://github.com/SkappHQ/skapp/issues/1880) would close the visibility leak while silently dropping the rep's own deal-linked tasks from the tab.

This PR brings the v2 filter in line with what it replaces:

contactId now matches the task's own contact or the contact on the task's deal.
The contact and deal joins are hoisted out of the search-keyword branch so both branches share them, instead of adding a second pair of joins when a search and a contact filter are used together.
The owner scoping itself is unchanged — CrmTaskServiceImplV2.getTasks already passes an ownerId for Sales Representatives, and the paging total stays in step because the count query reuses the same predicates.

Note for reviewers: buildTaskPredicates is shared with the v1 findTasks and findCompletedTasks, so GET /crm/task?contactId=… widens the same way. That is deliberate — it makes the v1 task list agree with v1's own contact-detail query, which already matched both. All 73 existing v1 task tests still pass.

How to test
Pick a contact, and create a deal on that contact.
Create two tasks owned by the same Sales Representative: one linked directly to the contact, one linked only to the deal (no contact set).
Call GET /v2/crm/task?contactId={contactId} as that Sales Representative.
Both tasks come back, and totalItems is 2. On develop only the directly linked task is returned.
Create a second contact with its own deal, and a task on that deal. Repeat step 3 — that task must not appear.
As a different Sales Representative, repeat step 3 — none of the first rep's tasks appear.

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
