### PR TITLE
fix: Mark auto-appearing modals as alertdialog, exempt toast from modal freeze

### DIFF
--- a/frontend/src/community/attendance/components/organisms/TimeWidgetPopupController/TimeWidgetPopupController.tsx
+++ b/frontend/src/community/attendance/components/organisms/TimeWidgetPopupController/TimeWidgetPopupController.tsx
@@ -120,6 +120,13 @@ const TimeWidgetPopupController = (): JSX.Element => {
     return "";
   };
 
+  const getModalRole = (): "dialog" | "alertdialog" => {
+    if (isPreMidnightClockOutAlertOpen || isAutoClockOutMidnightModalOpen) {
+      return "alertdialog";
+    }
+    return "dialog";
+  };
+
   const handleCloseModal = (): void => {
     if (isAttendanceModalOpen) {
       handleCloseAttendanceModal();
@@ -162,6 +169,7 @@ const TimeWidgetPopupController = (): JSX.Element => {
       }
       onClose={handleCloseModal}
       modalHeader={getModalTitle()}
+      role={getModalRole()}
       content={modalContent()}
     />
   );

--- a/frontend/src/community/common/components/molecules/ToastMessage/ToastMessage.tsx
+++ b/frontend/src/community/common/components/molecules/ToastMessage/ToastMessage.tsx
@@ -72,6 +72,7 @@ const ToastMessage = ({
 
   return (
     <Snackbar
+      data-skapp-inert-skip
       key={key}
       open={open}
       autoHideDuration={autoHideDuration}

--- a/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
+++ b/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
@@ -65,6 +65,7 @@ const BirthdayModalShell: FC<Props> = ({
       <LargeModal
         id={id}
         isOpen
+        role="alertdialog"
         className="relative h-[603px] max-h-[85vh] w-[1107px] max-w-[92vw] overflow-hidden rounded-l-[42.69px] rounded-r-[24px] shadow-[0_20px_40px_rgba(0,0,0,0.15)]"
         imagePosition="left"
         backdropVariant="dark"


### PR DESCRIPTION
Adds role="alertdialog" to the modals that appear on their own rather than from a click — the Birthday Notification Modal, the Enterprise Announcement Modal, and the two timer-driven attendance alerts — so screen readers announce them immediately instead of the calmer default used for click-triggered modals. Also tags the toast (ToastMessage) so it stays reachable to screen readers even while a modal is open, once paired with the corresponding skapp-ui update.