### PR TITLE
fix: back button on leave calendar returns to Leave tab

### DIFF
--- a/frontend/pages/community/dashboard/index.tsx
+++ b/frontend/pages/community/dashboard/index.tsx
@@ -26,6 +26,7 @@ import {
   ManagerTypes
 } from "~community/common/types/AuthTypes";
 import { ModuleTypes } from "~community/common/types/CommonTypes";
+import { replaceTabQueryParam } from "~community/common/utils/commonUtil";
 import { getCurrentAndNextYear } from "~community/common/utils/dateTimeUtils";
 import { useGetLeaveAllocation } from "~community/leave/api/MyRequestApi";
 import { useGetMyPolicyBalances } from "~community/leave/api/PolicyLeaveApi";
@@ -97,7 +98,8 @@ const LeaveYearSelector: FC<{
 };
 
 const Dashboard: NextPage = () => {
-  const { query } = useRouter();
+  const router = useRouter();
+  const { query } = router;
 
   const queryMatches = useMediaQuery();
   const isBelow900 = queryMatches(MediaQueries.BELOW_900);
@@ -212,6 +214,21 @@ const Dashboard: NextPage = () => {
 
   const userRoles: RoleTypes[] = (user?.roles || []) as RoleTypes[];
   const visibleTabs = getVisibleTabs(userRoles);
+  const requestedTabIndex = visibleTabs.findIndex(
+    (tab) =>
+      typeof query.tab === "string" &&
+      tab.module.toLowerCase() === query.tab.toLowerCase()
+  );
+  const defaultActiveTab =
+    requestedTabIndex === -1 ? undefined : requestedTabIndex;
+
+  const handleTabChange = (index: number) => {
+    const selectedModule = visibleTabs[index]?.module;
+    if (selectedModule) {
+      replaceTabQueryParam(router.asPath, selectedModule.toLowerCase());
+    }
+  };
+
   const { selectedYear, setSelectedYear } = useLeaveStore((state) => state);
 
   const currentDate = DateTime.now();
@@ -275,7 +292,11 @@ const Dashboard: NextPage = () => {
             <LeaveAllocationSummary />
           </div>
         ) : (
-          <TabsContainer tabs={visibleTabs} />
+          <TabsContainer
+            tabs={visibleTabs}
+            defaultActiveTab={defaultActiveTab}
+            onTabChange={handleTabChange}
+          />
         )}
 
         <VersionUpgradeModal />

--- a/frontend/pages/community/dashboard/leave/resource-availability.tsx
+++ b/frontend/pages/community/dashboard/leave/resource-availability.tsx
@@ -29,7 +29,7 @@ const ResourceAvailability: NextPage = () => {
       title={translateText(["resourceAvailability"])}
       isDividerVisible={false}
       isBackButtonVisible={true}
-      onBackClick={() => router.replace(ROUTES.DASHBOARD.BASE)}
+      onBackClick={() => router.replace(`${ROUTES.DASHBOARD.BASE}?tab=leave`)}
     >
       <>
         <ResourceAvailabilityCalendar />

--- a/frontend/src/community/common/components/molecules/Tabs/Tabs.tsx
+++ b/frontend/src/community/common/components/molecules/Tabs/Tabs.tsx
@@ -8,13 +8,18 @@ import TabPanel from "./TabPanel";
 import styles from "./styles";
 
 // TabsContainer component
-const TabsContainer: React.FC<TabsComponentProps> = ({ tabs }) => {
-  const [value, setValue] = useState<number>(0);
+const TabsContainer: React.FC<TabsComponentProps> = ({
+  tabs,
+  defaultActiveTab = 0,
+  onTabChange
+}) => {
+  const [value, setValue] = useState<number>(defaultActiveTab);
   const theme = useTheme();
   const classes = styles(theme);
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
+    onTabChange?.(newValue);
   };
 
   return (

--- a/frontend/src/community/common/types/TabsTypes.ts
+++ b/frontend/src/community/common/types/TabsTypes.ts
@@ -13,4 +13,6 @@ export interface TabPanelProps {
 
 export interface TabsComponentProps {
   tabs: TabItem[];
+  defaultActiveTab?: number;
+  onTabChange?: (index: number) => void;
 }


### PR DESCRIPTION
Clicking back on the "View Full Calendar" page previously sent Super Admins, Leave Admins, and Leave Managers to the Attendance tab instead of the Leave tab. The back button now navigates to /dashboard?tab=leave, and the Dashboard page reads that param to open directly on the Leave tab, with tab order and switching behavior unchanged for all other cases.