### PR TITLE
Fix/company detail view truncation issue

### DIFF
--- a/frontend/src/community/crm/components/molecules/SidePanelDealSection/DealAccordionItemHeader.tsx
+++ b/frontend/src/community/crm/components/molecules/SidePanelDealSection/DealAccordionItemHeader.tsx
@@ -9,8 +9,10 @@ interface Props {
 }
 
 const DealAccordionItemHeader: React.FC<Props> = ({ deal }) => (
-  <div className="flex flex-col gap-[2px]">
-    <span className="body2">{deal.name}</span>
+  <div className="flex flex-col gap-[2px] min-w-0">
+    <div className="body2 truncate" title={deal.name}>
+      {deal.name}
+    </div>
     <div className="flex items-center gap-2 text-secondary-text">
       <span className="body3">
         {concatStrings([deal?.owner?.firstName, deal?.owner?.lastName ?? ""])}

--- a/frontend/src/community/crm/components/molecules/TaskRow/TaskRowContent.tsx
+++ b/frontend/src/community/crm/components/molecules/TaskRow/TaskRowContent.tsx
@@ -28,6 +28,7 @@ const TaskRowContent: FC<Props> = ({
       <div className="flex-1 min-w-0">
         <p
           className={`body2 leading-snug truncate ${applyCompletedStyle ? "line-through text-secondary-icon" : "text-black"}`}
+          title={task.name}
         >
           {task.name}
         </p>


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id])

### Summary

Long names and text were not handled properly in the CRM task row, which is used by the Company Detail side panel's Tasks tab (and by the Tasks page and Task/Deal side panels).

Two problems in `v2/TaskRow`:

- **Task name** — already truncated with an ellipsis, but hovering showed nothing, so the full name was unreadable.
- **Contact name** (the subtitle line under the task name) — had no truncation at all. A long contact name just overflowed and got clipped by the row's `overflow-hidden`: no ellipsis, no tooltip.

Fixed by:

- Adding `title` to the task name so the full value shows on hover.
- Giving the contact name `truncate` + `title`, and adding `min-w-0` to it and its parent flex row so it can actually shrink. Without `min-w-0` a flex item won't shrink below its content width, so `truncate` never takes effect and the text overflows instead.

Changes are **v2 only** — v1 is being removed, so the equivalent v1 components were deliberately left untouched.

Not changed, and why:

- `v2/SidePanelDealCard` (the v2 deal row) already has `truncate` + `title` on the deal name and `min-w-0` on its parent. No fix needed.
- Owner name / amount are intentionally not truncated — only the name field truncates.
- **Contacts tab** has no v2 component yet, so it's not covered here. It will need the same treatment when that component lands.

Note: the v2 `CompanySidePanel` declares the three tabs but doesn't render tab bodies yet, so the Company Detail view is still served by v1 today. These fixes take effect once the v2 tabs are wired up.

### How to test

1. Go to **CRM → Tasks**.
2. Create (or find) a task with a very long name, assigned to a contact with a very long name.
3. Check the task row:
   - The task name truncates with an ellipsis, and hovering shows the full name.
   - The contact name in the subtitle truncates with an ellipsis instead of overflowing the row, and hovering shows the full name.
4. Open a **Deal side panel** and confirm the tasks list behaves the same way.
5. Narrow the browser window to shrink the row and confirm nothing spills outside the row boundary.

### Project Checklist

- [x] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information

Net diff against `develop` is 2 files:

- `frontend/src/community/crm/v2/components/molecules/TaskRow/TaskRowContent.tsx`
- `frontend/src/community/crm/v2/components/molecules/TaskRow/TaskRowSubtitle.tsx`

Commit history contains earlier v1 changes that are reverted by the final commit, so reviewing commit-by-commit shows churn that isn't in the final diff. **Review the combined diff, and squash on merge.**